### PR TITLE
Remove link about testing software installations

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,11 +316,6 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 
 <h2 id="setup">Setup</h2>
 
-<p>
-  <a href="setup/index.html">This page</a> has instructions on testing
-  that you have the right software installed.
-</p>
-
 <div> <!-- Start of 'shell' section. -->
   <h3>The Bash Shell</h3>
 


### PR DESCRIPTION
This links to a page with Python scripts to test whether the necessary software is installed. But I think this is likely to be confusing for a novice R workshop, and it would require learners to install Python in addition to everything else. I propose removing this info. What do you think, @kbroman?
