### PR TITLE
git lessons: Fix tags for input/output/objectives

### DIFF
--- a/syllabus/git-00-intro.html
+++ b/syllabus/git-00-intro.html
@@ -80,9 +80,13 @@
 <li>It keeps a record of who made what changes when, so that if people have questions later on, they know who to ask.</li>
 <li>It's hard (but not impossible) to accidentally overlook or overwrite someone's changes: the version control system automatically notifies users whenever there's a conflict between one person's work and another's.</li>
 </ul>
-<div class="challenges" markdown="1">
-<h4>Challenges</h4>
+<div id="challenge" class="challenge panel panel-success">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-pencil"></span>Challenge</h3>
+</div>
+<div class="panel-body">
 <p>On Wikipedia all changes and their authors are tracked. You can go <a href="https://en.wikipedia.org/w/index.php?title=Mars&amp;action=history">here</a> and you will find the history of all changes done to the article about the planet Mars. Find the last edit done last month and look at the changes made by clicking on the &quot;prev&quot; link on the left of the history entry.</p>
+</div>
 </div>
 <p>This lesson shows how to use a popular open source version control system called Git. It is more complex than some alternatives, but it is widely used, both because it's easy to set up and because of a hosting site called <a href="http://github.com">GitHub</a>. No matter which version control system you use, the most important thing to learn is not the details of their more obscure commands, but the workflow that they encourage.</p>
         </div>

--- a/syllabus/git-00-intro.md
+++ b/syllabus/git-00-intro.md
@@ -81,17 +81,13 @@ Version control is better than mailing files back and forth because:
     the version control system automatically notifies users
     whenever there's a conflict between one person's work and another's.
 
-<div class="challenges" markdown="1">
-
-#### Challenges
-
-On Wikipedia all changes and their authors are tracked. You can go
-[here](https://en.wikipedia.org/w/index.php?title=Mars&action=history)
-and you will find the history of all changes done to the article about the planet
-Mars. Find the last edit done last month and look at the changes made by
-clicking on the "prev" link on the left of the history entry.
-
-</div>
+> ### Challenge {.challenge}
+>
+> On Wikipedia all changes and their authors are tracked. You can go
+> [here](https://en.wikipedia.org/w/index.php?title=Mars&action=history)
+> and you will find the history of all changes done to the article about the planet
+> Mars. Find the last edit done last month and look at the changes made by
+> clicking on the "prev" link on the left of the history entry.
 
 This lesson shows how to use
 a popular open source version control system called Git.

--- a/syllabus/git-01-backup.html
+++ b/syllabus/git-01-backup.html
@@ -27,8 +27,11 @@
         <div class="col-md-10 col-md-offset-1">
           <h1 class="title">A Better Kind of Backup</h1>
           
-<div class="objectives" markdown="1">
-<h4>Objectives</h4>
+<div id="objectives" class="objectives panel panel-warning">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-certificate"></span>Objectives</h3>
+</div>
+<div class="panel-body">
 <ul>
 <li>Explain which initialization and configuration steps are required once per machine, and which are required once per repository.</li>
 <li>Go through the modify-add-commit cycle for single and multiple files and explain where information is stored at each stage.</li>
@@ -37,6 +40,7 @@
 <li>Restore old versions of files.</li>
 <li>Configure Git to ignore specific files, and explain why it is sometimes useful to do so.</li>
 </ul>
+</div>
 </div>
 <p>We'll start by exploring how version control can be used to keep track of what one person did and when. Even if you aren't collaborating with other people, version control is much better for this than this:</p>
 <div>
@@ -49,11 +53,10 @@
 <p>Git will keep track of the <em>changes</em> to your files, rather than keep multiple copies of the files. It saves the first version, then keeps track of subsequent changes to that version. This makes it efficient and speedy. It can recreate any version (go back in time) by adding up all the changes to get to where you want to be.</p>
 <h3 id="setting-up">Setting Up</h3>
 <p>The first time we use Git on a new machine, we need to configure a few things. Here's how Dracula sets up his new laptop:</p>
-<pre><code>$ git config --global user.name &quot;Vlad Dracula&quot;
-$ git config --global user.email &quot;vlad@tran.sylvan.ia&quot;
-$ git config --global color.ui &quot;auto&quot;
-$ git config --global core.editor &quot;nano&quot;</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> config --global user.name <span class="st">&quot;Vlad Dracula&quot;</span>
+$ <span class="kw">git</span> config --global user.email <span class="st">&quot;vlad@tran.sylvan.ia&quot;</span>
+$ <span class="kw">git</span> config --global color.ui <span class="st">&quot;auto&quot;</span>
+$ <span class="kw">git</span> config --global core.editor <span class="st">&quot;nano&quot;</span></code></pre>
 <p>(Please use your own name and email address instead of Dracula's, and please make sure you choose an editor that's actually on your system, such as <code>notepad</code> on Windows.)</p>
 <p>Git commands are written <code>git verb</code>, where <code>verb</code> is what we actually want it to do. In this case, we're telling Git:</p>
 <ul>
@@ -66,55 +69,69 @@ $ git config --global core.editor &quot;nano&quot;</code></pre>
 <blockquote>
 <h4>Proxy</h4>
 <p>In some networks you need to use a proxy. If this is the case you may also need to tell Git about the proxy:</p>
-<pre><code>$ git config --global http.proxy proxy-url
-$ git config --global https.proxy proxy-url</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> config --global http.proxy proxy-url
+$ <span class="kw">git</span> config --global https.proxy proxy-url</code></pre>
 <p>To disable the proxy, use</p>
-<pre><code>$ git config --global --unset http.proxy
-$ git config --global --unset https.proxy</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> config --global --unset http.proxy
+$ <span class="kw">git</span> config --global --unset https.proxy</code></pre>
 </blockquote>
 <h3 id="creating-a-repository">Creating a Repository</h3>
 <p>Once Git is configured, we can start using it. Let's create a directory for our work:</p>
-<pre><code>$ mkdir planets
-$ cd planets</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">mkdir</span> planets
+$ <span class="kw">cd</span> planets</code></pre>
 <p>and tell Git to make it a <a href="../../gloss.html#repository">repository</a>—a place where Git can store old versions of our files:</p>
-<pre><code>$ git init</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> init</code></pre>
 <p>If we use <code>ls</code> to show the directory's contents, it appears that nothing has changed:</p>
-<pre><code>$ ls</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">ls</span></code></pre>
 <p>But if we add the <code>-a</code> flag to show everything, we can see that Git has created a hidden directory called <code>.git</code>:</p>
-<pre><code>$ ls -a</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> . .. .git <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">ls</span> -a</code></pre>
+<pre class="output"><code>.   ..  .git</code></pre>
 <p>Git stores information about the project in this special sub-directory. If we ever delete it, we will lose the project's history.</p>
 <p>We can check that everything is set up correctly by asking Git to tell us the status of our project:</p>
-<pre><code>$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # # Initial commit # nothing to commit (create/copy files and use &quot;git add&quot; to track) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+#
+# Initial commit
+#
+nothing to commit (create/copy files and use &quot;git add&quot; to track)</code></pre>
 <p><em>On the white board draw a box representing the working area and explain that this is where you work and make changes.</em></p>
 <h3 id="tracking-changes-to-files">Tracking Changes to Files</h3>
 <p>Let's create a file called <code>mars.txt</code> that contains some notes about the Red Planet's suitability as a base. (We'll use <code>nano</code> to edit the file; you can use whatever editor you like. In particular, this does not have to be the core.editor you set globally earlier.) <em>also create a second file named venus.txt</em></p>
-<pre><code>$ nano mars.txt</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">nano</span> mars.txt</code></pre>
 <p>Type the text below into the <code>mars.txt</code> file:</p>
-<pre><code>Cold and dry, but everything is my favorite color</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">Cold</span> and dry, but everything is my favorite color</code></pre>
 <p><code>mars.txt</code> now contains a single line:</p>
-<pre><code>$ ls</code></pre>
-<p>{:class=&quot;in&quot;} <sub><sub><sub> mars.txt </sub></sub></sub> {:class=&quot;out&quot;} <sub>~</sub> $ cat mars.txt <sub><sub><sub> {:class=&quot;in&quot;} </sub></sub></sub> Cold and dry, but everything is my favorite color <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">ls</span></code></pre>
+<pre class="output"><code>mars.txt</code></pre>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color</code></pre>
 <p>If we check the status of our project again, Git tells us that it's noticed the new file:</p>
-<pre><code>$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # # Initial commit # # Untracked files: # (use &quot;git add <file>...&quot; to include in what will be committed) # # mars.txt nothing added to commit but untracked files present (use &quot;git add&quot; to track) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+#
+# Initial commit
+#
+# Untracked files:
+#   (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+#
+#   mars.txt
+nothing added to commit but untracked files present (use &quot;git add&quot; to track)</code></pre>
 <p>The &quot;untracked files&quot; message means that there's a file in the directory that Git isn't keeping track of.</p>
 <p><em>Now, lets add files that are inside: On the white board draw a box representing the staging area (index) and explain that this is where we set up the next snapshot of our project. Like a photographer in a studio, we're putting together a shot before we actually snap the picture. Connect the working area box and the staging box with 'git add'.</em></p>
 <p><em><code>git add .</code> This adds <strong>all</strong> the files in our repository. But sometimes we only want to add a single file at a time.</em></p>
 <p>We can tell Git that it should do so using <code>git add</code>:</p>
-<pre><code>$ git add mars.txt</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add mars.txt</code></pre>
 <p>and then check that the right thing happened:</p>
-<pre><code>$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # # Initial commit # # Changes to be committed: # (use &quot;git rm --cached <file>...&quot; to unstage) # # new file: mars.txt # <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+#
+# Initial commit
+#
+# Changes to be committed:
+#   (use &quot;git rm --cached &lt;file&gt;...&quot; to unstage)
+#
+#   new file:   mars.txt
+#</code></pre>
 <p><em>-- highlight the &quot;Untracked files&quot; section and that git tells you how to add a file to the next commit.</em></p>
 <p>Git now knows that it's supposed to keep track of <code>mars.txt</code>, but it hasn't yet recorded any changes for posterity as a commit.</p>
 <p><em>Tell git </em>&quot;Hey, we want you to remember the way that the files look right now&quot;<em>.</em></p>
@@ -122,56 +139,55 @@ $ cd planets</code></pre>
 <p><strong>ADVICE: Commit often</strong> <em>In the same way that it is wise to often save a document that you are working on, so too is it wise to save numerous revisions of your code. More frequent commits increase the granularity of your undo button.</em></p>
 <p><strong>ADVICE: Good commit messages</strong> <a href="http://www.commitlogsfromlastnight.com/">because it's important!</a> <em>There are no hard and fast rules, but good commits are atomic: they are the smallest change that remain meaningful. A good commit message usually contains a one-line description followed by a longer explanation if necessary. For code, it's useful to commit changes that can be reviewed by someone in under an hour. Or it can be useful to commit changes that &quot;go together&quot; - for example, one paragraph of a manuscript, or each new function added to your script. For example, if you work on your code all day long (add 200 lines of code, including 5 new functions and write 7 pages of your new manuscript including deleting an old paragraph), and at 3:00 you make a fatal error or deletion, but you didn't commit once, then you will have a hard time recreating the version you are looking for - because it doesn't exist!</em></p>
 <p>To get it to do that, we need to run one more command:</p>
-<pre><code>$ git commit -m &quot;Starting to think about Mars&quot;</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> [master (root-commit) f22b25e] Starting to think about Mars 1 file changed, 1 insertion(+) create mode 100644 mars.txt <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&quot;Starting to think about Mars&quot;</span></code></pre>
+<pre class="output"><code>[master (root-commit) f22b25e] Starting to think about Mars
+ 1 file changed, 1 insertion(+)
+ create mode 100644 mars.txt</code></pre>
 <p>When we run <code>git commit</code>, Git takes everything we have told it to save by using <code>git add</code> and stores a copy permanently inside the special <code>.git</code> directory. This permanent copy is called a <a href="../../gloss.html#revision">revision</a> and its short identifier is <code>f22b25e</code>. (Your revision may have another identifier.)</p>
 <p>We use the <code>-m</code> flag (for &quot;message&quot;) to record a comment that will help us remember later on what we did and why. If we just run <code>git commit</code> without the <code>-m</code> option, Git will launch <code>nano</code> (or whatever other editor we configured at the start) so that we can write a longer message.</p>
 <p><strong>ADVICE:</strong> <em>You must have a commit message. It's good practice and git won't let you commit without one.</em></p>
 <p><em>If you only want to add one file, use <code>git commit filename.txt -m &quot;message&quot;</code>git commit -am &quot;message` will add ALL tracked files.</em></p>
 <p>If we run <code>git status</code> now:</p>
-<pre><code>$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master nothing to commit, working directory clean <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+nothing to commit, working directory clean</code></pre>
 <p>it tells us everything is up to date. If we want to know what we've done recently, we can ask Git to show us the project's history using <code>git log</code>. You can see all the changes you have ever made using this command:</p>
-<pre><code>$ git log</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> commit f22b25e3233b4645dabd0d81e651fe074bd8e73b Author: Vlad Dracula <script type="text/javascript">
-<!--
-h='&#116;&#114;&#x61;&#110;&#46;&#x73;&#x79;&#108;&#118;&#x61;&#110;&#46;&#x69;&#x61;';a='&#64;';n='&#118;&#108;&#x61;&#100;';e=n+a+h;
-document.write('<a h'+'ref'+'="ma'+'ilto'+':'+e+'" clas'+'s="em' + 'ail">'+e+'<\/'+'a'+'>');
-// -->
-</script><noscript>&#118;&#108;&#x61;&#100;&#32;&#x61;&#116;&#32;&#116;&#114;&#x61;&#110;&#32;&#100;&#x6f;&#116;&#32;&#x73;&#x79;&#108;&#118;&#x61;&#110;&#32;&#100;&#x6f;&#116;&#32;&#x69;&#x61;</noscript> Date: Thu Aug 22 09:51:46 2013 -0400</p>
-<pre><code>Starting to think about Mars</code></pre>
-<pre><code>{:class=&quot;out&quot;}
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> log</code></pre>
+<pre class="output"><code>commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
+Author: Vlad Dracula &lt;vlad@tran.sylvan.ia&gt;
+Date:   Thu Aug 22 09:51:46 2013 -0400
 
-`git log` lists all revisions  made to a repository in reverse chronological order.
-The listing for each revision includes
-the revision&#39;s full identifier
-(which starts with the same characters as
-the short identifier printed by the `git commit` command earlier),
-the revision&#39;s author,
-when it was created,
-and the log message Git was given when the revision was created.
-
-&gt; #### Where Are My Changes?
-&gt;
-&gt; If we run `ls` at this point, we will still see just one file called `mars.txt`.
-&gt; That&#39;s because Git saves information about files&#39; history
-&gt; in the special `.git` directory mentioned earlier
-&gt; so that our filesystem doesn&#39;t become cluttered
-&gt; (and so that we can&#39;t accidentally edit or delete an old version).
-
-### Changing a File
-
-Now suppose Dracula adds more information to the file.
-(Again, we&#39;ll edit with `nano` and then `cat` the file to show its contents;
-you may use a different editor, and don&#39;t need to `cat`.)
-</code></pre>
-<p>$ nano mars.txt $ cat mars.txt <sub><sub><sub> {:class=&quot;in&quot;} </sub></sub></sub> Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman <sub>~</sub> {:class=&quot;out&quot;}</p>
+    Starting to think about Mars</code></pre>
+<p><code>git log</code> lists all revisions made to a repository in reverse chronological order. The listing for each revision includes the revision's full identifier (which starts with the same characters as the short identifier printed by the <code>git commit</code> command earlier), the revision's author, when it was created, and the log message Git was given when the revision was created.</p>
+<blockquote>
+<h4>Where Are My Changes?</h4>
+<p>If we run <code>ls</code> at this point, we will still see just one file called <code>mars.txt</code>. That's because Git saves information about files' history in the special <code>.git</code> directory mentioned earlier so that our filesystem doesn't become cluttered (and so that we can't accidentally edit or delete an old version).</p>
+</blockquote>
+<h3 id="changing-a-file">Changing a File</h3>
+<p>Now suppose Dracula adds more information to the file. (Again, we'll edit with <code>nano</code> and then <code>cat</code> the file to show its contents; you may use a different editor, and don't need to <code>cat</code>.)</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">nano</span> mars.txt
+$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman</code></pre>
 <p>When we run <code>git status</code> now, it tells us that a file it already knows about has been modified:</p>
-<pre><code>$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # Changes not staged for commit: # (use &quot;git add <file>...&quot; to update what will be committed) # (use &quot;git checkout -- <file>...&quot; to discard changes in working directory) # # modified: mars.txt # no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+# Changes not staged for commit:
+#   (use &quot;git add &lt;file&gt;...&quot; to update what will be committed)
+#   (use &quot;git checkout -- &lt;file&gt;...&quot; to discard changes in working directory)
+#
+#   modified:   mars.txt
+#
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)</code></pre>
 <p>The last line is the key phrase: &quot;no changes added to commit&quot;. We have changed this file, but we haven't told Git we will want to save those changes (which we do with <code>git add</code>) much less actually saved them. Let's double-check our work using <code>git diff</code>, which shows us the differences between the current state of the file and the most recently saved version:</p>
-<pre><code>$ git diff</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> diff --git a/mars.txt b/mars.txt index df0654a..315bf3a 100644 --- a/mars.txt +++ b/mars.txt @@ -1 +1,2 @@ Cold and dry, but everything is my favorite color +The two moons may be a problem for Wolfman <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> diff</code></pre>
+<pre class="output"><code>diff --git a/mars.txt b/mars.txt
+index df0654a..315bf3a 100644
+--- a/mars.txt
++++ b/mars.txt
+@@ -1 +1,2 @@
+ Cold and dry, but everything is my favorite color
++The two moons may be a problem for Wolfman</code></pre>
 <p>The output is cryptic because it is actually a series of commands for tools like editors and <code>patch</code> telling them how to reconstruct one file given the other. If we can break it down into pieces:</p>
 <ol style="list-style-type: decimal">
 <li>The first line tells us that Git is producing output similar to the Unix <code>diff</code> command comparing the old and new versions of the file.</li>
@@ -179,80 +195,108 @@ you may use a different editor, and don&#39;t need to `cat`.)
 <li>The remaining lines show us the actual differences and the lines on which they occur. In particular, the <code>+</code> markers in the first column show where we are adding lines.</li>
 </ol>
 <p>Let's commit our change:</p>
-<pre><code>$ git commit -m &quot;Concerns about Mars&#39;s moons on my furry friend&quot;</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # Changes not staged for commit: # (use &quot;git add <file>...&quot; to update what will be committed) # (use &quot;git checkout -- <file>...&quot; to discard changes in working directory) # # modified: mars.txt # no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&quot;Concerns about Mars&#39;s moons on my furry friend&quot;</span></code></pre>
+<pre class="output"><code># On branch master
+# Changes not staged for commit:
+#   (use &quot;git add &lt;file&gt;...&quot; to update what will be committed)
+#   (use &quot;git checkout -- &lt;file&gt;...&quot; to discard changes in working directory)
+#
+#   modified:   mars.txt
+#
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)</code></pre>
 <p>Whoops: Git won't commit because we didn't use <code>git add</code> first. Let's fix that:</p>
-<pre><code>$ git add mars.txt
-$ git commit -m &quot;Concerns about Mars&#39;s moons on my furry friend&quot;</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> [master 34961b1] Concerns about Mars's moons on my furry friend 1 file changed, 1 insertion(+) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add mars.txt
+$ <span class="kw">git</span> commit -m <span class="st">&quot;Concerns about Mars&#39;s moons on my furry friend&quot;</span></code></pre>
+<pre class="output"><code>[master 34961b1] Concerns about Mars&#39;s moons on my furry friend
+ 1 file changed, 1 insertion(+)</code></pre>
 <p>Git insists that we add files to the set we want to commit before actually committing anything because we may not want to commit everything at once. For example, suppose we're adding a few citations to our supervisor's work to our thesis. We might want to commit those additions, and the corresponding addition to the bibliography, but <em>not</em> commit the work we're doing on the conclusion (which we haven't finished yet).</p>
 <p>To allow for this, Git has a special staging area where it keeps track of things that have been added to the current <a href="../../gloss.html#change-set">change set</a> but not yet committed. <code>git add</code> puts things in this area, and <code>git commit</code> then copies them to long-term storage (as a commit):</p>
 <p><img src="img/git-staging-area.svg" alt="The Git Staging Area" /></p>
 <p>Let's watch as our changes to a file move from our editor to the staging area and into long-term storage. First, we'll add another line to the file:</p>
-<pre><code>$ nano mars.txt
-$ cat mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman But the Mummy will appreciate the lack of humidity <sub><sub><sub> {:class=&quot;out&quot;} </sub></sub></sub> $ git diff <sub><sub><sub> {:class=&quot;in&quot;} </sub></sub></sub> diff --git a/mars.txt b/mars.txt index 315bf3a..b36abfd 100644 --- a/mars.txt +++ b/mars.txt @@ -1,2 +1,3 @@ Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman +But the Mummy will appreciate the lack of humidity <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">nano</span> mars.txt
+$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+But the Mummy will appreciate the lack of humidity</code></pre>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> diff</code></pre>
+<pre class="output"><code>diff --git a/mars.txt b/mars.txt
+index 315bf3a..b36abfd 100644
+--- a/mars.txt
++++ b/mars.txt
+@@ -1,2 +1,3 @@
+ Cold and dry, but everything is my favorite color
+ The two moons may be a problem for Wolfman
++But the Mummy will appreciate the lack of humidity</code></pre>
 <p>So far, so good: we've added one line to the end of the file (shown with a <code>+</code> in the first column). Now let's put that change in the staging area and see what <code>git diff</code> reports:</p>
-<pre><code>$ git add mars.txt
-$ git diff</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add mars.txt
+$ <span class="kw">git</span> diff</code></pre>
 <p>There is no output: as far as Git can tell, there's no difference between what it's been asked to save permanently and what's currently in the directory. However, if we do this:</p>
-<pre><code>$ git diff --staged</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> diff --git a/mars.txt b/mars.txt index 315bf3a..b36abfd 100644 --- a/mars.txt +++ b/mars.txt @@ -1,2 +1,3 @@ Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman +But the Mummy will appreciate the lack of humidity <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> diff --staged</code></pre>
+<pre class="output"><code>diff --git a/mars.txt b/mars.txt
+index 315bf3a..b36abfd 100644
+--- a/mars.txt
++++ b/mars.txt
+@@ -1,2 +1,3 @@
+ Cold and dry, but everything is my favorite color
+ The two moons may be a problem for Wolfman
++But the Mummy will appreciate the lack of humidity</code></pre>
 <p>it shows us the difference between the last committed change and what's in the staging area. Let's save our changes:</p>
-<pre><code>$ git commit -m &quot;Thoughts about the climate&quot;</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> [master 005937f] Thoughts about the climate 1 file changed, 1 insertion(+) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&quot;Thoughts about the climate&quot;</span></code></pre>
+<pre class="output"><code>[master 005937f] Thoughts about the climate
+ 1 file changed, 1 insertion(+)</code></pre>
 <p>check our status:</p>
-<pre><code>$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master nothing to commit, working directory clean <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+nothing to commit, working directory clean</code></pre>
 <p>and look at the history of what we've done so far:</p>
-<pre><code>$ git log</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> commit 005937fbe2a98fb83f0ade869025dc2636b4dad5 Author: Vlad Dracula <script type="text/javascript">
-<!--
-h='&#116;&#114;&#x61;&#110;&#46;&#x73;&#x79;&#108;&#118;&#x61;&#110;&#46;&#x69;&#x61;';a='&#64;';n='&#118;&#108;&#x61;&#100;';e=n+a+h;
-document.write('<a h'+'ref'+'="ma'+'ilto'+':'+e+'" clas'+'s="em' + 'ail">'+e+'<\/'+'a'+'>');
-// -->
-</script><noscript>&#118;&#108;&#x61;&#100;&#32;&#x61;&#116;&#32;&#116;&#114;&#x61;&#110;&#32;&#100;&#x6f;&#116;&#32;&#x73;&#x79;&#108;&#118;&#x61;&#110;&#32;&#100;&#x6f;&#116;&#32;&#x69;&#x61;</noscript> Date: Thu Aug 22 10:14:07 2013 -0400</p>
-<pre><code>Thoughts about the climate</code></pre>
-<p>commit 34961b159c27df3b475cfe4415d94a6d1fcd064d Author: Vlad Dracula <script type="text/javascript">
-<!--
-h='&#116;&#114;&#x61;&#110;&#46;&#x73;&#x79;&#108;&#118;&#x61;&#110;&#46;&#x69;&#x61;';a='&#64;';n='&#118;&#108;&#x61;&#100;';e=n+a+h;
-document.write('<a h'+'ref'+'="ma'+'ilto'+':'+e+'" clas'+'s="em' + 'ail">'+e+'<\/'+'a'+'>');
-// -->
-</script><noscript>&#118;&#108;&#x61;&#100;&#32;&#x61;&#116;&#32;&#116;&#114;&#x61;&#110;&#32;&#100;&#x6f;&#116;&#32;&#x73;&#x79;&#108;&#118;&#x61;&#110;&#32;&#100;&#x6f;&#116;&#32;&#x69;&#x61;</noscript> Date: Thu Aug 22 10:07:21 2013 -0400</p>
-<pre><code>Concerns about Mars&#39;s moons on my furry friend</code></pre>
-<p>commit f22b25e3233b4645dabd0d81e651fe074bd8e73b Author: Vlad Dracula <script type="text/javascript">
-<!--
-h='&#116;&#114;&#x61;&#110;&#46;&#x73;&#x79;&#108;&#118;&#x61;&#110;&#46;&#x69;&#x61;';a='&#64;';n='&#118;&#108;&#x61;&#100;';e=n+a+h;
-document.write('<a h'+'ref'+'="ma'+'ilto'+':'+e+'" clas'+'s="em' + 'ail">'+e+'<\/'+'a'+'>');
-// -->
-</script><noscript>&#118;&#108;&#x61;&#100;&#32;&#x61;&#116;&#32;&#116;&#114;&#x61;&#110;&#32;&#100;&#x6f;&#116;&#32;&#x73;&#x79;&#108;&#118;&#x61;&#110;&#32;&#100;&#x6f;&#116;&#32;&#x69;&#x61;</noscript> Date: Thu Aug 22 09:51:46 2013 -0400</p>
-<pre><code>Starting to think about Mars</code></pre>
-<pre><code>{:class=&quot;out&quot;}
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> log</code></pre>
+<pre class="output"><code>commit 005937fbe2a98fb83f0ade869025dc2636b4dad5
+Author: Vlad Dracula &lt;vlad@tran.sylvan.ia&gt;
+Date:   Thu Aug 22 10:14:07 2013 -0400
 
-_Useful `git log` flags:_
+    Thoughts about the climate
 
-* -3 (shows only the 3 most recent commits)
-* --oneline (condenses each log into a single line, for quicker scanning)
-* --stat (gives more details for each commit, ++--)
-* --since=X.minutes/hours/days/weeks/months/years or YY-MM-DD-HH:MM (for specific time frames)
-* --author=&lt;pattern&gt; (look for specific people)
+commit 34961b159c27df3b475cfe4415d94a6d1fcd064d
+Author: Vlad Dracula &lt;vlad@tran.sylvan.ia&gt;
+Date:   Thu Aug 22 10:07:21 2013 -0400
 
-To recap, when we want to add changes to our repository,
-we first need to add the changed files to the staging area
-(`git add`) and then commit the staged changes to the
-repository (`git commit`):
+    Concerns about Mars&#39;s moons on my furry friend
 
-&lt;img src=&quot;img/git-committing.svg&quot; alt=&quot;The Git Commit Workflow&quot; /&gt;
+commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
+Author: Vlad Dracula &lt;vlad@tran.sylvan.ia&gt;
+Date:   Thu Aug 22 09:51:46 2013 -0400
 
-### Exploring History
-
-If we want to see what we changed when,
-we use `git diff` again,
-but refer to old versions
-using the notation `HEAD~1`, `HEAD~2`, and so on:
-</code></pre>
-<p>$ git diff HEAD~1 mars.txt <sub><sub><sub> {:class=&quot;in&quot;} </sub></sub></sub> diff --git a/mars.txt b/mars.txt index 315bf3a..b36abfd 100644 --- a/mars.txt +++ b/mars.txt @@ -1,2 +1,3 @@ Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman +But the Mummy will appreciate the lack of humidity <sub><sub><sub> {:class=&quot;out&quot;} </sub></sub></sub> $ git diff HEAD~2 mars.txt <sub><sub><sub> {:class=&quot;in&quot;} </sub></sub></sub> diff --git a/mars.txt b/mars.txt index df0654a..b36abfd 100644 --- a/mars.txt +++ b/mars.txt @@ -1 +1,3 @@ Cold and dry, but everything is my favorite color +The two moons may be a problem for Wolfman +But the Mummy will appreciate the lack of humidity <sub>~</sub> {:class=&quot;out&quot;}</p>
+    Starting to think about Mars</code></pre>
+<p><em>Useful <code>git log</code> flags:</em></p>
+<ul>
+<li>-3 (shows only the 3 most recent commits)</li>
+<li>--oneline (condenses each log into a single line, for quicker scanning)</li>
+<li>--stat (gives more details for each commit, ++--)</li>
+<li>--since=X.minutes/hours/days/weeks/months/years or YY-MM-DD-HH:MM (for specific time frames)</li>
+<li>--author=<pattern> (look for specific people)</li>
+</ul>
+<p>To recap, when we want to add changes to our repository, we first need to add the changed files to the staging area (<code>git add</code>) and then commit the staged changes to the repository (<code>git commit</code>):</p>
+<p><img src="img/git-committing.svg" alt="The Git Commit Workflow" /></p>
+<h3 id="exploring-history">Exploring History</h3>
+<p>If we want to see what we changed when, we use <code>git diff</code> again, but refer to old versions using the notation <code>HEAD~1</code>, <code>HEAD~2</code>, and so on:</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> diff HEAD~1 mars.txt</code></pre>
+<pre class="output"><code>diff --git a/mars.txt b/mars.txt
+index 315bf3a..b36abfd 100644
+--- a/mars.txt
++++ b/mars.txt
+@@ -1,2 +1,3 @@
+ Cold and dry, but everything is my favorite color
+ The two moons may be a problem for Wolfman
++But the Mummy will appreciate the lack of humidity</code></pre>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> diff HEAD~2 mars.txt</code></pre>
+<pre class="output"><code>diff --git a/mars.txt b/mars.txt
+index df0654a..b36abfd 100644
+--- a/mars.txt
++++ b/mars.txt
+@@ -1 +1,3 @@
+ Cold and dry, but everything is my favorite color
++The two moons may be a problem for Wolfman
++But the Mummy will appreciate the lack of humidity</code></pre>
 <p><em>Useful git diff flags</em></p>
 <ul>
 <li><code>git diff --stat</code> gives us a summary of the filename and number of insertions/deletions</li>
@@ -260,29 +304,51 @@ using the notation `HEAD~1`, `HEAD~2`, and so on:
 </ul>
 <p>In this way, we build up a chain of revisions. The most recent end of the chain is referred to as <code>HEAD</code>; we can refer to previous revisions using the <code>~</code> notation, so <code>HEAD~1</code> (pronounced &quot;head minus one&quot;) means &quot;the previous revision&quot;, while <code>HEAD~123</code> goes back 123 revisions from where we are now.</p>
 <p>We can also refer to revisions using those long strings of digits and letters that <code>git log</code> displays. These are unique IDs for the changes, and &quot;unique&quot; really does mean unique: every change to any set of files on any machine has a unique 40-character identifier. Our first commit was given the ID f22b25e3233b4645dabd0d81e651fe074bd8e73b, so let's try this:</p>
-<pre><code>$ git diff f22b25e3233b4645dabd0d81e651fe074bd8e73b mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> diff --git a/mars.txt b/mars.txt index df0654a..b36abfd 100644 --- a/mars.txt +++ b/mars.txt @@ -1 +1,3 @@ Cold and dry, but everything is my favorite color +The two moons may be a problem for Wolfman +But the Mummy will appreciate the lack of humidity <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> diff f22b25e3233b4645dabd0d81e651fe074bd8e73b mars.txt</code></pre>
+<pre class="output"><code>diff --git a/mars.txt b/mars.txt
+index df0654a..b36abfd 100644
+--- a/mars.txt
++++ b/mars.txt
+@@ -1 +1,3 @@
+ Cold and dry, but everything is my favorite color
++The two moons may be a problem for Wolfman
++But the Mummy will appreciate the lack of humidity</code></pre>
 <p>That's the right answer, but typing random 40-character strings is annoying, so Git lets us use just the first few:</p>
-<pre><code>$ git diff f22b25e mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> diff --git a/mars.txt b/mars.txt index df0654a..b36abfd 100644 --- a/mars.txt +++ b/mars.txt @@ -1 +1,3 @@ Cold and dry, but everything is my favorite color +The two moons may be a problem for Wolfman +But the Mummy will appreciate the lack of humidity <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> diff f22b25e mars.txt</code></pre>
+<pre class="output"><code>diff --git a/mars.txt b/mars.txt
+index df0654a..b36abfd 100644
+--- a/mars.txt
++++ b/mars.txt
+@@ -1 +1,3 @@
+ Cold and dry, but everything is my favorite color
++The two moons may be a problem for Wolfman
++But the Mummy will appreciate the lack of humidity</code></pre>
 <h3 id="recovering-old-versions">Recovering Old Versions</h3>
 <p><em>So far, this seems like a lot of work. Why are we keeping track of all these little things?? Let's say you fatally ruin a file during an editing mistake (like when I deleted an awesome paragraph from my dissertation instead of cutting and pasting it like I meant to.) Maybe you even accidentally delete an important file (This code is old, why should I keep it?). If you have version control, you don't need to track down your System Administrator. You can fix your problem easily!</em></p>
 <p>All right: we can save changes to files and see what we've changed---how can we restore older versions of things? Let's suppose we accidentally overwrite our file:</p>
-<pre><code>$ nano mars.txt
-$ cat mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> We will need to manufacture our own oxygen <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">nano</span> mars.txt
+$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>We will need to manufacture our own oxygen</code></pre>
 <p><code>git status</code> now tells us that the file has been changed, but those changes haven't been staged:</p>
-<pre><code>$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # Changes not staged for commit: # (use &quot;git add <file>...&quot; to update what will be committed) # (use &quot;git checkout -- <file>...&quot; to discard changes in working directory) # # modified: mars.txt # no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+# Changes not staged for commit:
+#   (use &quot;git add &lt;file&gt;...&quot; to update what will be committed)
+#   (use &quot;git checkout -- &lt;file&gt;...&quot; to discard changes in working directory)
+#
+#   modified:   mars.txt
+#
+no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&quot;)</code></pre>
 <p>We can put things back the way they were by using <code>git checkout</code>:</p>
-<pre><code>$ git checkout HEAD mars.txt
-$ cat mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman But the Mummy will appreciate the lack of humidity <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> checkout HEAD mars.txt
+$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+But the Mummy will appreciate the lack of humidity</code></pre>
 <p>As you might guess from its name, <code>git checkout</code> checks out (i.e., restores) an old version of a file. In this case, we're telling Git that we want to recover the version of the file recorded in <code>HEAD</code>, which is the last saved revision.</p>
 <p><em>This would work even if we deleted our file, and wanted to get it back!</em> <em>delete mars.txt, and then show that it can be checked back out</em></p>
 <p>If we want to go back even further, we can use a revision identifier instead:</p>
-<pre><code>$ git checkout f22b25e mars.txt</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> checkout f22b25e mars.txt</code></pre>
 <p>It's important to remember that we must use the revision number that identifies the state of the repository <em>before</em> the change we're trying to undo. A common mistake is to use the revision number of the commit in which we made the change we're trying to get rid of. In the example below, we want retrieve the state from before the most recent commit (<code>HEAD~1</code>), which is revision <code>f22b25e</code>:</p>
 <p><img src="img/git-checkout.svg" alt="Git Checkout" /></p>
 <p>The following diagram illustrates what the history of a file might look like (moving back from <code>HEAD</code>, the most recently committed version):</p>
@@ -290,8 +356,7 @@ $ cat mars.txt</code></pre>
 <blockquote>
 <h4>Simplifying the Common Case</h4>
 <p>If you read the output of <code>git status</code> carefully, you'll see that it includes this hint:</p>
-<pre><code>(use &quot;git checkout -- &lt;file&gt;...&quot; to discard changes in working directory)</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">(use</span> <span class="st">&quot;git checkout -- &lt;file&gt;...&quot;</span> to discard changes in working directory<span class="kw">)</span></code></pre>
 <p>As it says, <code>git checkout</code> without a version identifier restores files to the state saved in <code>HEAD</code>. The double dash <code>--</code> is needed to separate the names of the files being recovered from the command itself: without it, Git would try to use the name of the file as the revision identifier.</p>
 </blockquote>
 <p>The fact that files can be reverted one by one tends to change the way people organize their work. If everything is in one large document, it's hard (but not impossible) to undo changes to the introduction without also undoing changes made later to the conclusion. If the introduction and conclusion are stored in separate files, on the other hand, moving backward and forward in time becomes much easier. Or for your code, if you store functions in files separate from code that executes them, or makes figures, you can go back in time to find or retrieve specific chunks.</p>
@@ -299,41 +364,69 @@ $ cat mars.txt</code></pre>
 <p>What if we have files that we do not want Git to track for us, like backup files created by our editor or intermediate files created during data analysis.</p>
 <p><em>while git can keep track of data files, this is often not a great idea. Share story of .rdata files in collaborative project. Why they needed to be in the .git ignore file</em></p>
 <p>Let's create a few dummy files:</p>
-<pre><code>$ mkdir results
-$ touch a.dat b.dat c.dat results/a.out results/b.out</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">mkdir</span> results
+$ <span class="kw">touch</span> a.dat b.dat c.dat results/a.out results/b.out</code></pre>
 <p>and see what Git says:</p>
-<pre><code>$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # Untracked files: # (use &quot;git add <file>...&quot; to include in what will be committed) # # a.dat # b.dat # c.dat # results/ nothing added to commit but untracked files present (use &quot;git add&quot; to track) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+# Untracked files:
+#   (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+#
+#   a.dat
+#   b.dat
+#   c.dat
+#   results/
+nothing added to commit but untracked files present (use &quot;git add&quot; to track)</code></pre>
 <p><em>Note: if you already added these files (git add .) you can unstage them by typing git reset HEAD</em></p>
 <p>Putting these files under version control would be a waste of disk space. What's worse, having them all listed could distract us from changes that actually matter, so let's tell Git to ignore them.</p>
 <p>We do this by creating a file in the root directory of our project called <code>.gitignore</code>.</p>
-<pre><code>$ nano .gitignore
-$ cat .gitignore</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> *.dat results/ <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">nano</span> .gitignore
+$ <span class="kw">cat</span> .gitignore</code></pre>
+<pre class="output"><code>*.dat
+results/</code></pre>
 <p>These patterns tell Git to ignore any file whose name ends in <code>.dat</code> and everything in the <code>results</code> directory. (If any of these files were already being tracked, Git would continue to track them.)</p>
 <p>Once we have created this file, the output of <code>git status</code> is much cleaner:</p>
-<pre><code>$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # Untracked files: # (use &quot;git add <file>...&quot; to include in what will be committed) # # .gitignore nothing added to commit but untracked files present (use &quot;git add&quot; to track) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+# Untracked files:
+#   (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+#
+#   .gitignore
+nothing added to commit but untracked files present (use &quot;git add&quot; to track)</code></pre>
 <p>The only thing Git notices now is the newly-created <code>.gitignore</code> file. You might think we wouldn't want to track it, but everyone we're sharing our repository with will probably want to ignore the same things that we're ignoring. Let's add and commit <code>.gitignore</code>:</p>
-<pre><code>$ git add .gitignore
-$ git commit -m &quot;Add the ignore file&quot;
-$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master nothing to commit, working directory clean <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add .gitignore
+$ <span class="kw">git</span> commit -m <span class="st">&quot;Add the ignore file&quot;</span>
+$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+nothing to commit, working directory clean</code></pre>
 <p>As a bonus, using <code>.gitignore</code> helps us avoid accidentally adding files to the repository that we don't want.</p>
-<pre><code>$ git add a.dat</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> The following paths are ignored by one of your .gitignore files: a.dat Use -f if you really want to add them. fatal: no files added <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add a.dat</code></pre>
+<pre class="output"><code>The following paths are ignored by one of your .gitignore files:
+a.dat
+Use -f if you really want to add them.
+fatal: no files added</code></pre>
 <p>If we really want to override our ignore settings, we can use <code>git add -f</code> to force Git to add something. We can also always see the status of ignored files if we want:</p>
-<pre><code>$ git status --ignored</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # Ignored files: # (use &quot;git add -f <file>...&quot; to include in what will be committed) # # a.dat # b.dat # c.dat # results/</p>
-<p>nothing to commit, working directory clean <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> status --ignored</code></pre>
+<pre class="output"><code># On branch master
+# Ignored files:
+#  (use &quot;git add -f &lt;file&gt;...&quot; to include in what will be committed)
+#
+#        a.dat
+#        b.dat
+#        c.dat
+#        results/
+
+nothing to commit, working directory clean</code></pre>
 <p><em>To discard all your most recent changes and GO BACK IN TIME, first look at your <code>git log</code> to decide what version you want to go back to. Remember the first 5-7 digits in the commit code of the version that wasn't screwed up.</em></p>
 <p><em>use <code>git reset --hard versioncode</code></em></p>
 <p><em>To roll back to a specific file, use <code>git checkout version name --filename</code></em></p>
 <p><em>To roll back one version (usually I know that I messed up pretty quickly) <code>git checkout master~1 PathToFile</code></em></p>
 <p><em>A short exercise to show moving back and forth. If I mess up and I notice right away, might want to go back in time quickly. Commit some changes to <code>mars.txt</code>. I can return to the previous version by typing <code>git checkout master~1 mars.txt</code>, and then committing those changes with a message like &quot;I deleted the thing I just added&quot;. This will preserve your entire history, including the short-lived mistake, which will allow you to return to it if you should decide it wasn't a mistake at all. If you check out the entire repository using <code>git checkout master~1</code> you will be in &quot;detached head state&quot;. This can be quickly remedied by typing <code>git checkout master</code>, to return you to the correct place. Detached head is when the head is not the same version as the master.</em></p>
-<div class="keypoints" markdown="1">
-<h4>Key Points</h4>
+<div id="key-points" class="objectives panel panel-warning">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-certificate"></span>Key Points</h3>
+</div>
+<div class="panel-body">
 <ul>
 <li>Use <code>git config</code> to configure a user name, email address, editor, and other preferences once per machine.</li>
 <li><code>git init</code> initializes a repository.</li>
@@ -347,20 +440,26 @@ $ git status</code></pre>
 <li>The <code>.gitignore</code> file tells Git what files to ignore.</li>
 </ul>
 </div>
-<div class="challenge" markdown="1">
-Create a new Git repository on your computer called <code>bio</code>. Write a three-line biography for yourself in a file called <code>me.txt</code>, commit your changes, then modify one line and add a fourth and display the differences between its updated state and its original state.
 </div>
-<div class="challenge" markdown="1">
+<blockquote>
+<h3>Challenge</h3>
+<p>Create a new Git repository on your computer called <code>bio</code>. Write a three-line biography for yourself in a file called <code>me.txt</code>, commit your changes, then modify one line and add a fourth and display the differences between its updated state and its original state.</p>
+</blockquote>
+<div id="challenge-1" class="challenge panel panel-success">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-pencil"></span>Challenge</h3>
+</div>
+<div class="panel-body">
 <p>The following sequence of commands creates one Git repository inside another:</p>
-<pre><code>cd           # return to home directory
-mkdir alpha  # make a new directory alpha
-cd alpha     # go into alpha
-git init     # make the alpha directory a Git repository
-mkdir beta   # make a sub-directory alpha/beta
-cd beta      # go into alpha/beta
-git init     # make the beta sub-directory a Git repository</code></pre>
-<p>{:class=&quot;in&quot;}</p>
-Why is it a bad idea to do this?
+<pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">cd</span>           <span class="co"># return to home directory</span>
+<span class="kw">mkdir</span> alpha  <span class="co"># make a new directory alpha</span>
+<span class="kw">cd</span> alpha     <span class="co"># go into alpha</span>
+<span class="kw">git</span> init     <span class="co"># make the alpha directory a Git repository</span>
+<span class="kw">mkdir</span> beta   <span class="co"># make a sub-directory alpha/beta</span>
+<span class="kw">cd</span> beta      <span class="co"># go into alpha/beta</span>
+<span class="kw">git</span> init     <span class="co"># make the beta sub-directory a Git repository</span></code></pre>
+<p>Why is it a bad idea to do this?</p>
+</div>
 </div>
         </div>
       </div>

--- a/syllabus/git-01-backup.md
+++ b/syllabus/git-01-backup.md
@@ -4,20 +4,18 @@ root: ..
 title: A Better Kind of Backup
 ---
 
-<div class="objectives" markdown="1">
+> ### Objectives {.objectives}
+>
+> *   Explain which initialization and configuration steps are required once per machine,
+>     and which are required once per repository.
+> *   Go through the modify-add-commit cycle for single and multiple files
+>     and explain where information is stored at each stage.
+> *   Identify and use Git revision numbers.
+> *   Compare files with old versions of themselves.
+> *   Restore old versions of files.
+> *   Configure Git to ignore specific files,
+>     and explain why it is sometimes useful to do so.
 
-#### Objectives
-*   Explain which initialization and configuration steps are required once per machine,
-    and which are required once per repository.
-*   Go through the modify-add-commit cycle for single and multiple files
-    and explain where information is stored at each stage.
-*   Identify and use Git revision numbers.
-*   Compare files with old versions of themselves.
-*   Restore old versions of files.
-*   Configure Git to ignore specific files,
-    and explain why it is sometimes useful to do so.
-
-</div>
 
 We'll start by exploring how version control can be used
 to keep track of what one person did and when.
@@ -42,13 +40,12 @@ The first time we use Git on a new machine,
 we need to configure a few things.
 Here's how Dracula sets up his new laptop:
 
-~~~
+~~~ {.bash}
 $ git config --global user.name "Vlad Dracula"
 $ git config --global user.email "vlad@tran.sylvan.ia"
 $ git config --global color.ui "auto"
 $ git config --global core.editor "nano"
 ~~~
-{:class="in"}
 
 (Please use your own name and email address instead of Dracula's,
 and please make sure you choose an editor that's actually on your system,
@@ -72,19 +69,17 @@ the flag `--global` tells Git to use the settings for every project on this mach
 > In some networks you need to use a proxy. If this is the case you may also
 > need to tell Git about the proxy:
 >
-> ~~~
+> ~~~ {.bash}
 > $ git config --global http.proxy proxy-url
 > $ git config --global https.proxy proxy-url
 > ~~~
-> {:class="in"}
 >
 > To disable the proxy, use
 >
-> ~~~
+> ~~~ {.bash}
 > $ git config --global --unset http.proxy
 > $ git config --global --unset https.proxy
 > ~~~
-> {:class="in"}
 
 ### Creating a Repository
 
@@ -92,39 +87,35 @@ Once Git is configured,
 we can start using it.
 Let's create a directory for our work:
 
-~~~
+~~~ {.bash}
 $ mkdir planets
 $ cd planets
 ~~~
-{:class="in"}
 
 and tell Git to make it a [repository](../../gloss.html#repository)&mdash;a place where
 Git can store old versions of our files:
 
-~~~
+~~~ {.bash}
 $ git init
 ~~~
-{:class="in"}
 
 If we use `ls` to show the directory's contents,
 it appears that nothing has changed:
 
-~~~
+~~~ {.bash}
 $ ls
 ~~~
-{:class="in"}
 
 But if we add the `-a` flag to show everything,
 we can see that Git has created a hidden directory called `.git`:
 
-~~~
+~~~ {.bash}
 $ ls -a
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 .	..	.git
 ~~~
-{:class="out"}
 
 Git stores information about the project in this special sub-directory.
 If we ever delete it,
@@ -133,18 +124,17 @@ we will lose the project's history.
 We can check that everything is set up correctly
 by asking Git to tell us the status of our project:
 
-~~~
+~~~ {.bash}
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 #
 # Initial commit
 #
 nothing to commit (create/copy files and use "git add" to track)
 ~~~
-{:class="out"}
 
 _On the white board draw a box representing the working area and
  explain that this is where you work and make changes._
@@ -159,45 +149,42 @@ you can use whatever editor you like.
 In particular, this does not have to be the core.editor you set globally earlier.)
 _also create a second file named venus.txt_
 
-~~~
+~~~ {.bash}
 $ nano mars.txt
 ~~~
-{:class="in"}
 
 Type the text below into the `mars.txt` file:
 
-~~~
+~~~ {.bash}
 Cold and dry, but everything is my favorite color
 ~~~
-{:class="in"}
 
 `mars.txt` now contains a single line:
 
-~~~
+~~~ {.bash}
 $ ls
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 mars.txt
 ~~~
-{:class="out"}
-~~~
+
+~~~ {.bash}
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 ~~~
-{:class="out"}
 
 If we check the status of our project again,
 Git tells us that it's noticed the new file:
 
-~~~
+~~~ {.bash}
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 #
 # Initial commit
@@ -208,7 +195,6 @@ $ git status
 #	mars.txt
 nothing added to commit but untracked files present (use "git add" to track)
 ~~~
-{:class="out"}
 
 The "untracked files" message means that there's a file in the directory
 that Git isn't keeping track of.
@@ -225,18 +211,17 @@ But sometimes we only want to add a single file at a time._
 
 We can tell Git that it should do so using `git add`:
 
-~~~
+~~~ {.bash}
 $ git add mars.txt
 ~~~
-{:class="in"}
 
 and then check that the right thing happened:
 
-~~~
+~~~ {.bash}
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 #
 # Initial commit
@@ -247,7 +232,6 @@ $ git status
 #	new file:   mars.txt
 #
 ~~~
-{:class="out"}
 
 
 _-- highlight the "Untracked files" section and that git tells you how to add a file to the next commit._
@@ -283,16 +267,15 @@ For example, if you work on your code all day long (add 200 lines of code, inclu
 To get it to do that,
 we need to run one more command:
 
-~~~
+~~~ {.bash}
 $ git commit -m "Starting to think about Mars"
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 [master (root-commit) f22b25e] Starting to think about Mars
  1 file changed, 1 insertion(+)
  create mode 100644 mars.txt
 ~~~
-{:class="out"}
 
 When we run `git commit`,
 Git takes everything we have told it to save by using `git add`
@@ -314,33 +297,31 @@ _If you only want to add one file, use `git commit filename.txt -m "message"
 
 If we run `git status` now:
 
-~~~
+~~~ {.bash}
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 nothing to commit, working directory clean
 ~~~
-{:class="out"}
 
 it tells us everything is up to date.
 If we want to know what we've done recently,
 we can ask Git to show us the project's history using `git log`.
 You can see all the changes you have ever made using this command:
 
-~~~
+~~~ {.bash}
 $ git log
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 commit f22b25e3233b4645dabd0d81e651fe074bd8e73b
 Author: Vlad Dracula <vlad@tran.sylvan.ia>
 Date:   Thu Aug 22 09:51:46 2013 -0400
 
     Starting to think about Mars
 ~~~
-{:class="out"}
 
 `git log` lists all revisions  made to a repository in reverse chronological order.
 The listing for each revision includes
@@ -365,25 +346,24 @@ Now suppose Dracula adds more information to the file.
 (Again, we'll edit with `nano` and then `cat` the file to show its contents;
 you may use a different editor, and don't need to `cat`.)
 
-~~~
+~~~ {.bash}
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 The two moons may be a problem for Wolfman
 ~~~
-{:class="out"}
 
 When we run `git status` now,
 it tells us that a file it already knows about has been modified:
 
-~~~
+~~~ {.bash}
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 # Changes not staged for commit:
 #   (use "git add <file>..." to update what will be committed)
@@ -393,7 +373,6 @@ $ git status
 #
 no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
-{:class="out"}
 
 The last line is the key phrase:
 "no changes added to commit".
@@ -406,11 +385,11 @@ which shows us the differences between
 the current state of the file
 and the most recently saved version:
 
-~~~
+~~~ {.bash}
 $ git diff
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 diff --git a/mars.txt b/mars.txt
 index df0654a..315bf3a 100644
 --- a/mars.txt
@@ -419,7 +398,6 @@ index df0654a..315bf3a 100644
  Cold and dry, but everything is my favorite color
 +The two moons may be a problem for Wolfman
 ~~~
-{:class="out"}
 
 The output is cryptic because
 it is actually a series of commands for tools like editors and `patch`
@@ -438,11 +416,11 @@ If we can break it down into pieces:
 
 Let's commit our change:
 
-~~~
+~~~ {.bash}
 $ git commit -m "Concerns about Mars's moons on my furry friend"
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 # Changes not staged for commit:
 #   (use "git add <file>..." to update what will be committed)
@@ -452,22 +430,20 @@ $ git commit -m "Concerns about Mars's moons on my furry friend"
 #
 no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
-{:class="out"}
 
 Whoops:
 Git won't commit because we didn't use `git add` first.
 Let's fix that:
 
-~~~
+~~~ {.bash}
 $ git add mars.txt
 $ git commit -m "Concerns about Mars's moons on my furry friend"
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 [master 34961b1] Concerns about Mars's moons on my furry friend
  1 file changed, 1 insertion(+)
 ~~~
-{:class="out"}
 
 Git insists that we add files to the set we want to commit
 before actually committing anything
@@ -496,22 +472,22 @@ and into long-term storage.
 First,
 we'll add another line to the file:
 
-~~~
+~~~ {.bash}
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 The two moons may be a problem for Wolfman
 But the Mummy will appreciate the lack of humidity
 ~~~
-{:class="out"}
-~~~
+
+~~~ {.bash}
 $ git diff
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 diff --git a/mars.txt b/mars.txt
 index 315bf3a..b36abfd 100644
 --- a/mars.txt
@@ -521,7 +497,6 @@ index 315bf3a..b36abfd 100644
  The two moons may be a problem for Wolfman
 +But the Mummy will appreciate the lack of humidity
 ~~~
-{:class="out"}
 
 So far, so good:
 we've added one line to the end of the file
@@ -529,11 +504,10 @@ we've added one line to the end of the file
 Now let's put that change in the staging area
 and see what `git diff` reports:
 
-~~~
+~~~ {.bash}
 $ git add mars.txt
 $ git diff
 ~~~
-{:class="in"}
 
 There is no output:
 as far as Git can tell,
@@ -542,11 +516,11 @@ and what's currently in the directory.
 However,
 if we do this:
 
-~~~
+~~~ {.bash}
 $ git diff --staged
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 diff --git a/mars.txt b/mars.txt
 index 315bf3a..b36abfd 100644
 --- a/mars.txt
@@ -556,42 +530,39 @@ index 315bf3a..b36abfd 100644
  The two moons may be a problem for Wolfman
 +But the Mummy will appreciate the lack of humidity
 ~~~
-{:class="out"}
 
 it shows us the difference between
 the last committed change
 and what's in the staging area.
 Let's save our changes:
 
-~~~
+~~~ {.bash}
 $ git commit -m "Thoughts about the climate"
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 [master 005937f] Thoughts about the climate
  1 file changed, 1 insertion(+)
 ~~~
-{:class="out"}
 
 check our status:
 
-~~~
+~~~ {.bash}
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 nothing to commit, working directory clean
 ~~~
-{:class="out"}
 
 and look at the history of what we've done so far:
 
-~~~
+~~~ {.bash}
 $ git log
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 commit 005937fbe2a98fb83f0ade869025dc2636b4dad5
 Author: Vlad Dracula <vlad@tran.sylvan.ia>
 Date:   Thu Aug 22 10:14:07 2013 -0400
@@ -610,7 +581,6 @@ Date:   Thu Aug 22 09:51:46 2013 -0400
 
     Starting to think about Mars
 ~~~
-{:class="out"}
 
 _Useful `git log` flags:_
 
@@ -634,11 +604,11 @@ we use `git diff` again,
 but refer to old versions
 using the notation `HEAD~1`, `HEAD~2`, and so on:
 
-~~~
+~~~ {.bash}
 $ git diff HEAD~1 mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 diff --git a/mars.txt b/mars.txt
 index 315bf3a..b36abfd 100644
 --- a/mars.txt
@@ -648,12 +618,12 @@ index 315bf3a..b36abfd 100644
  The two moons may be a problem for Wolfman
 +But the Mummy will appreciate the lack of humidity
 ~~~
-{:class="out"}
-~~~
+
+~~~ {.bash}
 $ git diff HEAD~2 mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 diff --git a/mars.txt b/mars.txt
 index df0654a..b36abfd 100644
 --- a/mars.txt
@@ -663,7 +633,6 @@ index df0654a..b36abfd 100644
 +The two moons may be a problem for Wolfman
 +But the Mummy will appreciate the lack of humidity
 ~~~
-{:class="out"}
 
 _Useful git diff flags_
 
@@ -689,11 +658,11 @@ Our first commit was given the ID
 f22b25e3233b4645dabd0d81e651fe074bd8e73b,
 so let's try this:
 
-~~~
+~~~ {.bash}
 $ git diff f22b25e3233b4645dabd0d81e651fe074bd8e73b mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 diff --git a/mars.txt b/mars.txt
 index df0654a..b36abfd 100644
 --- a/mars.txt
@@ -703,17 +672,16 @@ index df0654a..b36abfd 100644
 +The two moons may be a problem for Wolfman
 +But the Mummy will appreciate the lack of humidity
 ~~~
-{:class="out"}
 
 That's the right answer,
 but typing random 40-character strings is annoying,
 so Git lets us use just the first few:
 
-~~~
+~~~ {.bash}
 $ git diff f22b25e mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 diff --git a/mars.txt b/mars.txt
 index df0654a..b36abfd 100644
 --- a/mars.txt
@@ -723,7 +691,6 @@ index df0654a..b36abfd 100644
 +The two moons may be a problem for Wolfman
 +But the Mummy will appreciate the lack of humidity
 ~~~
-{:class="out"}
 
 ### Recovering Old Versions
 
@@ -738,24 +705,23 @@ we can save changes to files and see what we've changed---how
 can we restore older versions of things?
 Let's suppose we accidentally overwrite our file:
 
-~~~
+~~~ {.bash}
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 We will need to manufacture our own oxygen
 ~~~
-{:class="out"}
 
 `git status` now tells us that the file has been changed,
 but those changes haven't been staged:
 
-~~~
+~~~ {.bash}
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 # Changes not staged for commit:
 #   (use "git add <file>..." to update what will be committed)
@@ -765,22 +731,20 @@ $ git status
 #
 no changes added to commit (use "git add" and/or "git commit -a")
 ~~~
-{:class="out"}
 
 We can put things back the way they were
 by using `git checkout`:
 
-~~~
+~~~ {.bash}
 $ git checkout HEAD mars.txt
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 The two moons may be a problem for Wolfman
 But the Mummy will appreciate the lack of humidity
 ~~~
-{:class="out"}
 
 As you might guess from its name,
 `git checkout` checks out (i.e., restores) an old version of a file.
@@ -794,10 +758,9 @@ _delete mars.txt, and then show that it can be checked back out_
 If we want to go back even further,
 we can use a revision identifier instead:
 
-~~~
+~~~ {.bash}
 $ git checkout f22b25e mars.txt
 ~~~
-{:class="in"}
 
 It's important to remember that
 we must use the revision number that identifies the state of the repository
@@ -819,10 +782,9 @@ like (moving back from `HEAD`, the most recently committed version):
 > If you read the output of `git status` carefully,
 > you'll see that it includes this hint:
 >
-> ~~~
+> ~~~ {.bash}
 > (use "git checkout -- <file>..." to discard changes in working directory)
 > ~~~
-> {:class="in"}
 >
 > As it says,
 > `git checkout` without a version identifier restores files to the state saved in `HEAD`.
@@ -853,19 +815,18 @@ Share story of .rdata files in collaborative project. Why they needed to be in t
 
 Let's create a few dummy files:
 
-~~~
+~~~ {.bash}
 $ mkdir results
 $ touch a.dat b.dat c.dat results/a.out results/b.out
 ~~~
-{:class="in"}
 
 and see what Git says:
 
-~~~
+~~~ {.bash}
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 # Untracked files:
 #   (use "git add <file>..." to include in what will be committed)
@@ -876,7 +837,6 @@ $ git status
 #	results/
 nothing added to commit but untracked files present (use "git add" to track)
 ~~~
-{:class="out"}
 
 _Note: if you already added these files (git add .) you can unstage them by typing git reset HEAD_
 
@@ -887,16 +847,15 @@ so let's tell Git to ignore them.
 
 We do this by creating a file in the root directory of our project called `.gitignore`.
 
-~~~
+~~~ {.bash}
 $ nano .gitignore
 $ cat .gitignore
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 *.dat
 results/
 ~~~
-{:class="out"}
 
 These patterns tell Git to ignore any file whose name ends in `.dat`
 and everything in the `results` directory.
@@ -906,11 +865,11 @@ Git would continue to track them.)
 Once we have created this file,
 the output of `git status` is much cleaner:
 
-~~~
+~~~ {.bash}
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 # Untracked files:
 #   (use "git add <file>..." to include in what will be committed)
@@ -918,7 +877,6 @@ $ git status
 #	.gitignore
 nothing added to commit but untracked files present (use "git add" to track)
 ~~~
-{:class="out"}
 
 The only thing Git notices now is the newly-created `.gitignore` file.
 You might think we wouldn't want to track it,
@@ -926,42 +884,40 @@ but everyone we're sharing our repository with will probably want to ignore
 the same things that we're ignoring.
 Let's add and commit `.gitignore`:
 
-~~~
+~~~ {.bash}
 $ git add .gitignore
 $ git commit -m "Add the ignore file"
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 nothing to commit, working directory clean
 ~~~
-{:class="out"}
 
 As a bonus,
 using `.gitignore` helps us avoid accidentally adding files to the repository that we don't want.
 
-~~~
+~~~ {.bash}
 $ git add a.dat
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 The following paths are ignored by one of your .gitignore files:
 a.dat
 Use -f if you really want to add them.
 fatal: no files added
 ~~~
-{:class="out"}
 
 If we really want to override our ignore settings,
 we can use `git add -f` to force Git to add something.
 We can also always see the status of ignored files if we want:
 
-~~~
+~~~ {.bash}
 $ git status --ignored
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 # Ignored files:
 #  (use "git add -f <file>..." to include in what will be committed)
@@ -973,7 +929,6 @@ $ git status --ignored
 
 nothing to commit, working directory clean
 ~~~
-{:class="out"}
 
 _To discard all your most recent changes and GO BACK IN TIME,
 first look at your `git log` to decide what version you want to go back to.
@@ -999,45 +954,42 @@ _A short exercise to show moving back and forth. If I mess up and I notice right
  you to the correct place. Detached head is when the head is not the same version as the master._
 
 
-<div class="keypoints" markdown="1">
+> ### Key Points {.objectives}
+>
+> *   Use `git config` to configure a user name, email address, editor, and other preferences once per machine.
+> *   `git init` initializes a repository.
+> *   `git status` shows the status of a repository.
+> *   Files can be stored in a project's working directory (which users see),
+>     the staging area (where the next commit is being built up)
+>     and the local repository (where snapshots are permanently recorded).
+> *   `git add` puts files in the staging area.
+> *   `git commit` creates a snapshot of the staging area in the local repository.
+> *   Always write a log message when committing changes.
+> *   `git diff` displays differences between revisions.
+> *   `git checkout` recovers old versions of files.
+> *   The `.gitignore` file tells Git what files to ignore.
 
-#### Key Points
-*   Use `git config` to configure a user name, email address, editor, and other preferences once per machine.
-*   `git init` initializes a repository.
-*   `git status` shows the status of a repository.
-*   Files can be stored in a project's working directory (which users see),
-    the staging area (where the next commit is being built up)
-    and the local repository (where snapshots are permanently recorded).
-*   `git add` puts files in the staging area.
-*   `git commit` creates a snapshot of the staging area in the local repository.
-*   Always write a log message when committing changes.
-*   `git diff` displays differences between revisions.
-*   `git checkout` recovers old versions of files.
-*   The `.gitignore` file tells Git what files to ignore.
+> ### Challenge {.challange}
+>
+> Create a new Git repository on your computer called `bio`.
+> Write a three-line biography for yourself in a file called `me.txt`,
+> commit your changes,
+> then modify one line and add a fourth and display the differences
+> between its updated state and its original state.
 
-</div>
-
-<div class="challenge" markdown="1">
-Create a new Git repository on your computer called `bio`.
-Write a three-line biography for yourself in a file called `me.txt`,
-commit your changes,
-then modify one line and add a fourth and display the differences
-between its updated state and its original state.
-</div>
-
-<div class="challenge" markdown="1">
-The following sequence of commands creates one Git repository inside another:
-
-~~~
-cd           # return to home directory
-mkdir alpha  # make a new directory alpha
-cd alpha     # go into alpha
-git init     # make the alpha directory a Git repository
-mkdir beta   # make a sub-directory alpha/beta
-cd beta      # go into alpha/beta
-git init     # make the beta sub-directory a Git repository
-~~~
-{:class="in"}
-
-Why is it a bad idea to do this?
-</div>
+> ### Challenge {.challenge}
+>
+> The following sequence of commands creates one Git repository inside another:
+>
+> ~~~ {.bash}
+> cd           # return to home directory
+> mkdir alpha  # make a new directory alpha
+> cd alpha     # go into alpha
+> git init     # make the alpha directory a Git repository
+> mkdir beta   # make a sub-directory alpha/beta
+> cd beta      # go into alpha/beta
+> git init     # make the beta sub-directory a Git repository
+> ~~~
+>
+>
+> Why is it a bad idea to do this?

--- a/syllabus/git-02-collab.html
+++ b/syllabus/git-02-collab.html
@@ -27,13 +27,17 @@
         <div class="col-md-10 col-md-offset-1">
           <h1 class="title">Collaborating</h1>
           
-<div class="objectives" markdown="1">
-<h4>Objectives</h4>
+<div id="objectives" class="objectives panel panel-warning">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-certificate"></span>Objectives</h3>
+</div>
+<div class="panel-body">
 <ul>
 <li>Explain what remote repositories are and why they are useful.</li>
 <li>Explain what happens when a remote repository is cloned.</li>
 <li>Explain what happens when changes are pushed to or pulled from a remote repository.</li>
 </ul>
+</div>
 </div>
 <p>Version control really comes into its own when we begin to collaborate with other people. We already have most of the machinery we need to do this; the only thing missing is to copy changes from one repository to another.</p>
 <p>Systems like Git allow us to move work between any two repositories. In practice, though, it's easiest to use one copy as a central hub, and to keep it on the web rather than on someone's laptop. Most programmers use hosting services like <a href="http://github.com">GitHub</a> or <a href="http://bitbucket.org">BitBucket</a> to hold those master copies; we'll explore the pros and cons of this in the final section of this lesson.</p>
@@ -82,10 +86,9 @@
 <p>As soon as the repository is created, GitHub displays a page with a URL and some information on how to configure your local repository:</p>
 <p><img src="img/github-create-repo-03.png" alt="Creating a Repository on GitHub (Step 3)" /></p>
 <p>This effectively does the following on GitHub's servers:</p>
-<pre><code>$ mkdir planets
-$ cd planets
-$ git init</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">mkdir</span> planets
+$ <span class="kw">cd</span> planets
+$ <span class="kw">git</span> init</code></pre>
 <p>Our local repository still contains our earlier work on <code>mars.txt</code>, but the remote repository on GitHub doesn't contain any files yet:</p>
 <p><img src="img/git-freshly-made-github-repo.svg" alt="Freshly-Made GitHub Repository" /></p>
 <p>The next step is to connect the two repositories. We do this by making the GitHub repository a <a href="../../gloss.html#remote-repository">remote</a> for the local repository. The home page of the repository on GitHub includes the string we need to identify it:</p>
@@ -98,33 +101,37 @@ $ git init</code></pre>
 </blockquote>
 <p><img src="img/github-change-repo-string.png" alt="Changing the Repository URL on GitHub" /></p>
 <p>Copy that URL from the browser, go into the local <code>planets</code> repository, and run this command:</p>
-<pre><code>$ git remote add origin https://github.com/vlad/planets.git</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> remote add origin https://github.com/vlad/planets.git</code></pre>
 <p>Make sure to use the URL for your repository rather than Vlad's: the only difference should be your username instead of <code>vlad</code>.</p>
 <p>We can check that the command has worked by running <code>git remote -v</code>:</p>
-<pre><code>$ git remote -v</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> origin https://github.com/vlad/planets.git (push) origin https://github.com/vlad/planets.git (fetch) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> remote -v</code></pre>
+<pre class="output"><code>origin   https://github.com/vlad/planets.git (push)
+origin   https://github.com/vlad/planets.git (fetch)</code></pre>
 <p>The name <code>origin</code> is a local nickname for your remote repository: we could use something else if we wanted to, but <code>origin</code> is by far the most common choice.</p>
 <p>Once the nickname <code>origin</code> is set up, this command will push the changes from our local repository to the repository on GitHub:</p>
-<pre><code>$ git push origin master</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Counting objects: 9, done. Delta compression using up to 4 threads. Compressing objects: 100% (6/6), done. Writing objects: 100% (9/9), 821 bytes, done. Total 9 (delta 2), reused 0 (delta 0) To https://github.com/vlad/planets * [new branch] master -&gt; master Branch master set up to track remote branch master from origin. <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> push origin master</code></pre>
+<pre class="output"><code>Counting objects: 9, done.
+Delta compression using up to 4 threads.
+Compressing objects: 100% (6/6), done.
+Writing objects: 100% (9/9), 821 bytes, done.
+Total 9 (delta 2), reused 0 (delta 0)
+To https://github.com/vlad/planets
+ * [new branch]      master -&gt; master
+Branch master set up to track remote branch master from origin.</code></pre>
 <p><strong>Show that the files now exist online</strong></p>
 <blockquote>
 <h5>Proxy</h5>
 <p>If the network you are connected to uses a proxy there is an chance that your last command failed with &quot;Could not resolve hostname&quot; as the error message. To solve this issue you need to tell Git about the proxy:</p>
-<pre><code>$ git config --global http.proxy http://user:password@proxy.url
-$ git config --global https.proxy http://user:password@proxy.url</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> config --global http.proxy http://user:password@proxy.url
+$ <span class="kw">git</span> config --global https.proxy http://user:password@proxy.url</code></pre>
 <p>When you connect to another network that doesn't use a proxy you will need to tell Git to disable the proxy using</p>
-<pre><code>$ git config --global --unset http.proxy
-$ git config --global --unset https.proxy</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> config --global --unset http.proxy
+$ <span class="kw">git</span> config --global --unset https.proxy</code></pre>
 </blockquote>
 <blockquote>
 <h4>Password Managers</h4>
 <p>If your operating system has a password manager configured, <code>git push</code> will try to use it when it needs your username and password. If you want to type your username and password at the terminal instead of using a password manager, type</p>
-<pre><code>$ unset SSH_ASKPASS</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">unset</span> <span class="ot">SSH_ASKPASS</span></code></pre>
 <p>You may want to add this command at the end of your <code>~/.bashrc</code> to make it the default behavior.</p>
 </blockquote>
 <p>Our local and remote repositories are now in this state:</p>
@@ -134,8 +141,10 @@ $ git config --global --unset https.proxy</code></pre>
 <p>You may see a <code>-u</code> option used with <code>git push</code> in some documentation. It is related to concepts we cover in our intermediate lesson, and can safely be ignored for now.</p>
 </blockquote>
 <p>We can pull changes from the remote repository to the local one as well:</p>
-<pre><code>$ git pull origin master</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> From https://github.com/vlad/planets * branch master -&gt; FETCH_HEAD Already up-to-date. <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> pull origin master</code></pre>
+<pre class="output"><code>From https://github.com/vlad/planets
+ * branch            master     -&gt; FETCH_HEAD
+Already up-to-date.</code></pre>
 <p>Pulling has no effect in this case because the two repositories are already synchronized. If someone else had pushed some changes to the repository on GitHub, though, this command would download them to our local repository.</p>
 <p><strong>Add a README.md file on the browser. Demonstrate pulling changes back down to your machine</strong> <strong>Add NASA data to my local repository (http://www.nasa.gov/open/data.html). Push changes</strong></p>
 <p>For the next step, get into pairs. Pick one of your repositories on Github to use for collaboration.</p>
@@ -147,25 +156,47 @@ $ git config --global --unset https.proxy</code></pre>
 <p><strong>Demonstrate how to add collaborators</strong></p>
 <p><img src="img/github-add-collaborators.png" alt="Adding collaborators on Github" /></p>
 <p>The other partner should <code>cd</code> to another directory (so <code>ls</code> doesn't show a <code>planets</code> folder), and then make a copy of this repository on your own computer:</p>
-<pre><code>$ git clone https://github.com/vlad/planets.git</code></pre>
-<p>{:class=&quot;in&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> clone https://github.com/vlad/planets.git</code></pre>
 <p>Replace 'vlad' with your partner's username (the one who owns the repository).</p>
 <p><code>git clone</code> creates a fresh local copy of a remote repository.</p>
 <p><img src="img/github-collaboration.svg" alt="After Creating Clone of Repository" /></p>
 <p>The new collaborator can now make a change in their copy of the repository:</p>
-<pre><code>$ cd planets
-$ nano pluto.txt
-$ cat pluto.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> It is so a planet! <sub><sub><sub> {:class=&quot;out&quot;} </sub></sub></sub> $ git add pluto.txt $ git commit -m &quot;Some notes about Pluto&quot; <sub><sub><sub> {:class=&quot;in&quot;} </sub></sub></sub> 1 file changed, 1 insertion(+) create mode 100644 pluto.txt <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">cd</span> planets
+$ <span class="kw">nano</span> pluto.txt
+$ <span class="kw">cat</span> pluto.txt</code></pre>
+<pre class="output"><code>It is so a planet!</code></pre>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add pluto.txt
+$ <span class="kw">git</span> commit -m <span class="st">&quot;Some notes about Pluto&quot;</span></code></pre>
+<pre class="output"><code> 1 file changed, 1 insertion(+)
+ create mode 100644 pluto.txt</code></pre>
 <p>then push the change to GitHub:</p>
-<pre><code>$ git push origin master</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Counting objects: 4, done. Delta compression using up to 4 threads. Compressing objects: 100% (2/2), done. Writing objects: 100% (3/3), 306 bytes, done. Total 3 (delta 0), reused 0 (delta 0) To https://github.com/vlad/planets.git 9272da5..29aba7c master -&gt; master <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> push origin master</code></pre>
+<pre class="output"><code>Counting objects: 4, done.
+Delta compression using up to 4 threads.
+Compressing objects: 100% (2/2), done.
+Writing objects: 100% (3/3), 306 bytes, done.
+Total 3 (delta 0), reused 0 (delta 0)
+To https://github.com/vlad/planets.git
+   9272da5..29aba7c  master -&gt; master</code></pre>
 <p>Note that we didn't have to create a remote called <code>origin</code>: Git does this automatically, using that name, when we clone a repository. (This is why <code>origin</code> was a sensible choice earlier when we were setting up remotes by hand.)</p>
 <p>We can now download changes into the original repository on our machine:</p>
-<pre><code>$ git pull origin master</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> remote: Counting objects: 4, done. remote: Compressing objects: 100% (2/2), done. remote: Total 3 (delta 0), reused 3 (delta 0) Unpacking objects: 100% (3/3), done. From https://github.com/vlad/planets * branch master -&gt; FETCH_HEAD Updating 9272da5..29aba7c Fast-forward pluto.txt | 1 + 1 file changed, 1 insertion(+) create mode 100644 pluto.txt <sub>~</sub> {:class=&quot;out&quot;}</p>
-<div class="keypoints" markdown="1">
-<h4>Key Points</h4>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> pull origin master</code></pre>
+<pre class="output"><code>remote: Counting objects: 4, done.
+remote: Compressing objects: 100% (2/2), done.
+remote: Total 3 (delta 0), reused 3 (delta 0)
+Unpacking objects: 100% (3/3), done.
+From https://github.com/vlad/planets
+ * branch            master     -&gt; FETCH_HEAD
+Updating 9272da5..29aba7c
+Fast-forward
+ pluto.txt | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 pluto.txt</code></pre>
+<div id="key-points" class="objectives panel panel-warning">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-certificate"></span>Key Points</h3>
+</div>
+<div class="panel-body">
 <ul>
 <li>A local Git repository can be connected to one or more remote repositories.</li>
 <li>Use the HTTPS protocol to connect to remote repositories until you have learned how to set up SSH.</li>
@@ -174,8 +205,14 @@ $ cat pluto.txt</code></pre>
 <li><code>git clone</code> copies a remote repository to create a local repository with a remote called <code>origin</code> automatically set up.</li>
 </ul>
 </div>
-<div class="challenge" markdown="1">
-Create a repository on GitHub, clone it, add a file, push those changes to GitHub, and then look at the <a href="../../gloss.html#timestamp">timestamp</a> of the change on GitHub. How does GitHub record times, and why?
+</div>
+<div id="challenge" class="challenge panel panel-success">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-pencil"></span>Challenge</h3>
+</div>
+<div class="panel-body">
+<p>Create a repository on GitHub, clone it, add a file, push those changes to GitHub, and then look at the <a href="../../gloss.html#timestamp">timestamp</a> of the change on GitHub. How does GitHub record times, and why?</p>
+</div>
 </div>
         </div>
       </div>

--- a/syllabus/git-02-collab.md
+++ b/syllabus/git-02-collab.md
@@ -4,14 +4,11 @@ root: ..
 title: Collaborating
 ---
 
-<div class="objectives" markdown="1">
-
-#### Objectives
-*   Explain what remote repositories are and why they are useful.
-*   Explain what happens when a remote repository is cloned.
-*   Explain what happens when changes are pushed to or pulled from a remote repository.
-
-</div>
+> ### Objectives {.objectives}
+>
+> *   Explain what remote repositories are and why they are useful.
+> *   Explain what happens when a remote repository is cloned.
+> *   Explain what happens when changes are pushed to or pulled from a remote repository.
 
 Version control really comes into its own
 when we begin to collaborate with other people.
@@ -99,12 +96,11 @@ GitHub displays a page with a URL and some information on how to configure your 
 
 This effectively does the following on GitHub's servers:
 
-~~~
+~~~ {.bash}
 $ mkdir planets
 $ cd planets
 $ git init
 ~~~
-{:class="in"}
 
 Our local repository still contains our earlier work on `mars.txt`,
 but the remote repository on GitHub doesn't contain any files yet:
@@ -140,25 +136,23 @@ Copy that URL from the browser,
 go into the local `planets` repository,
 and run this command:
 
-~~~
+~~~ {.bash}
 $ git remote add origin https://github.com/vlad/planets.git
 ~~~
-{:class="in"}
 
 Make sure to use the URL for your repository rather than Vlad's:
 the only difference should be your username instead of `vlad`.
 
 We can check that the command has worked by running `git remote -v`:
 
-~~~
+~~~ {.bash}
 $ git remote -v
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 origin   https://github.com/vlad/planets.git (push)
 origin   https://github.com/vlad/planets.git (fetch)
 ~~~
-{:class="out"}
 
 The name `origin` is a local nickname for your remote repository:
 we could use something else if we wanted to,
@@ -168,11 +162,11 @@ Once the nickname `origin` is set up,
 this command will push the changes from our local repository
 to the repository on GitHub:
 
-~~~
+~~~ {.bash}
 $ git push origin master
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Counting objects: 9, done.
 Delta compression using up to 4 threads.
 Compressing objects: 100% (6/6), done.
@@ -182,7 +176,6 @@ To https://github.com/vlad/planets
  * [new branch]      master -> master
 Branch master set up to track remote branch master from origin.
 ~~~
-{:class="out"}
 
 __Show that the files now exist online__
 
@@ -193,20 +186,18 @@ __Show that the files now exist online__
 > command failed with "Could not resolve hostname" as the error message. To
 > solve this issue you need to tell Git about the proxy:
 >
-> ~~~
+> ~~~ {.bash}
 > $ git config --global http.proxy http://user:password@proxy.url
 > $ git config --global https.proxy http://user:password@proxy.url
 > ~~~
-> {:class="in"}
 >
 > When you connect to another network that doesn't use a proxy you will need to
 > tell Git to disable the proxy using
 >
-> ~~~
+> ~~~ {.bash}
 > $ git config --global --unset http.proxy
 > $ git config --global --unset https.proxy
 > ~~~
-> {:class="in"}
 
 > #### Password Managers
 >
@@ -215,10 +206,9 @@ __Show that the files now exist online__
 > your username and password at the terminal instead of using
 > a password manager, type
 >
-> ~~~
+> ~~~ {.bash}
 > $ unset SSH_ASKPASS
 > ~~~
-> {:class="in"}
 >
 > You may want to add this command at the end of your `~/.bashrc` to make it the
 > default behavior.
@@ -235,16 +225,15 @@ Our local and remote repositories are now in this state:
 
 We can pull changes from the remote repository to the local one as well:
 
-~~~
+~~~ {.bash}
 $ git pull origin master
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 From https://github.com/vlad/planets
  * branch            master     -> FETCH_HEAD
 Already up-to-date.
 ~~~
-{:class="out"}
 
 Pulling has no effect in this case
 because the two repositories are already synchronized.
@@ -277,10 +266,9 @@ The other partner should `cd` to another directory
 (so `ls` doesn't show a `planets` folder),
 and then make a copy of this repository on your own computer:
 
-~~~
+~~~ {.bash}
 $ git clone https://github.com/vlad/planets.git
 ~~~
-{:class="in"}
 
 Replace 'vlad' with your partner's username (the one who owns the repository).
 
@@ -290,34 +278,33 @@ Replace 'vlad' with your partner's username (the one who owns the repository).
 
 The new collaborator can now make a change in their copy of the repository:
 
-~~~
+~~~ {.bash}
 $ cd planets
 $ nano pluto.txt
 $ cat pluto.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 It is so a planet!
 ~~~
-{:class="out"}
-~~~
+
+~~~ {.bash}
 $ git add pluto.txt
 $ git commit -m "Some notes about Pluto"
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
  1 file changed, 1 insertion(+)
  create mode 100644 pluto.txt
 ~~~
-{:class="out"}
 
 then push the change to GitHub:
 
-~~~
+~~~ {.bash}
 $ git push origin master
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Counting objects: 4, done.
 Delta compression using up to 4 threads.
 Compressing objects: 100% (2/2), done.
@@ -326,7 +313,6 @@ Total 3 (delta 0), reused 0 (delta 0)
 To https://github.com/vlad/planets.git
    9272da5..29aba7c  master -> master
 ~~~
-{:class="out"}
 
 Note that we didn't have to create a remote called `origin`:
 Git does this automatically,
@@ -337,11 +323,11 @@ when we were setting up remotes by hand.)
 
 We can now download changes into the original repository on our machine:
 
-~~~
+~~~ {.bash}
 $ git pull origin master
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 remote: Counting objects: 4, done.
 remote: Compressing objects: 100% (2/2), done.
 remote: Total 3 (delta 0), reused 3 (delta 0)
@@ -354,24 +340,21 @@ Fast-forward
  1 file changed, 1 insertion(+)
  create mode 100644 pluto.txt
 ~~~
-{:class="out"}
 
-<div class="keypoints" markdown="1">
+> ### Key Points {.objectives}
+>
+> *   A local Git repository can be connected to one or more remote repositories.
+> *   Use the HTTPS protocol to connect to remote repositories until you have learned how to set up SSH.
+> *   `git push` copies changes from a local repository to a remote repository.
+> *   `git pull` copies changes from a remote repository to a local repository.
+> *   `git clone` copies a remote repository to create a local repository with a remote called `origin` automatically set up.
 
-#### Key Points
-*   A local Git repository can be connected to one or more remote repositories.
-*   Use the HTTPS protocol to connect to remote repositories until you have learned how to set up SSH.
-*   `git push` copies changes from a local repository to a remote repository.
-*   `git pull` copies changes from a remote repository to a local repository.
-*   `git clone` copies a remote repository to create a local repository with a remote called `origin` automatically set up.
 
-</div>
-
-<div class="challenge" markdown="1">
-Create a repository on GitHub,
-clone it,
-add a file,
-push those changes to GitHub,
-and then look at the [timestamp](../../gloss.html#timestamp) of the change on GitHub.
-How does GitHub record times, and why?
-</div>
+> ### Challenge {.challenge}
+>
+> Create a repository on GitHub,
+> clone it,
+> add a file,
+> push those changes to GitHub,
+> and then look at the [timestamp](../../gloss.html#timestamp) of the change on GitHub.
+> How does GitHub record times, and why?

--- a/syllabus/git-03-conflict.html
+++ b/syllabus/git-03-conflict.html
@@ -27,75 +27,162 @@
         <div class="col-md-10 col-md-offset-1">
           <h1 class="title">Conflicts</h1>
           
-<div class="objectives" markdown="1">
-<h4>Objectives</h4>
+<div id="objectives" class="objectives panel panel-warning">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-certificate"></span>Objectives</h3>
+</div>
+<div class="panel-body">
 <ul>
 <li>Explain what conflicts are and when they can occur.</li>
 <li>Resolve conflicts resulting from a merge.</li>
 </ul>
 </div>
+</div>
 <p>As soon as people can work in parallel, someone's going to step on someone else's toes. This will even happen with a single person: if we are working on a piece of software on both our laptop and a server in the lab, we could make different changes to each copy. Version control helps us manage these <a href="../../gloss.html#conflict">conflicts</a> by giving us tools to <a href="../../gloss.html#resolve">resolve</a> overlapping changes.</p>
 <p>To see how we can resolve conflicts, we must first create one. The file <code>mars.txt</code> currently looks like this in both partners' copies of our <code>planets</code> repository:</p>
-<pre><code>$ cat mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman But the Mummy will appreciate the lack of humidity <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+But the Mummy will appreciate the lack of humidity</code></pre>
 <p>Let's add a line to <strong>one partner's copy</strong> only:</p>
-<pre><code>$ nano mars.txt
-$ cat mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman But the Mummy will appreciate the lack of humidity This line added to Sarah's copy <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">nano</span> mars.txt
+$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+But the Mummy will appreciate the lack of humidity
+This line added to Sarah&#39;s copy</code></pre>
 <p>and then push the change to GitHub:</p>
-<pre><code>$ git add mars.txt
-$ git commit -m &quot;Adding a line in our home copy&quot;</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> [master 5ae9631] Adding a line in our home copy 1 file changed, 1 insertion(+) <sub><sub><sub> {:class=&quot;out&quot;} </sub></sub></sub> $ git push origin master <sub><sub><sub> {:class=&quot;in&quot;} </sub></sub></sub> Counting objects: 5, done. Delta compression using up to 4 threads. Compressing objects: 100% (3/3), done. Writing objects: 100% (3/3), 352 bytes, done. Total 3 (delta 1), reused 0 (delta 0) To https://github.com/vlad/planets 29aba7c..dabb4c8 master -&gt; master <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add mars.txt
+$ <span class="kw">git</span> commit -m <span class="st">&quot;Adding a line in our home copy&quot;</span></code></pre>
+<pre class="output"><code>[master 5ae9631] Adding a line in our home copy
+ 1 file changed, 1 insertion(+)</code></pre>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> push origin master</code></pre>
+<pre class="output"><code>Counting objects: 5, done.
+Delta compression using up to 4 threads.
+Compressing objects: 100% (3/3), done.
+Writing objects: 100% (3/3), 352 bytes, done.
+Total 3 (delta 1), reused 0 (delta 0)
+To https://github.com/vlad/planets
+   29aba7c..dabb4c8  master -&gt; master</code></pre>
 <p>Now let's have the other partner make a different change to their copy <em>without</em> updating from GitHub:</p>
-<pre><code>$ cd /tmp/planets
-$ nano mars.txt
-$ cat mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman But the Mummy will appreciate the lack of humidity We added a different line in the other copy <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">cd</span> /tmp/planets
+$ <span class="kw">nano</span> mars.txt
+$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+But the Mummy will appreciate the lack of humidity
+We added a different line in the other copy</code></pre>
 <p>We can commit the change locally:</p>
-<pre><code>$ git add mars.txt
-$ git commit -m &quot;Adding a line in my copy&quot;</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> [master 07ebc69] Adding a line in my copy 1 file changed, 1 insertion(+) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add mars.txt
+$ <span class="kw">git</span> commit -m <span class="st">&quot;Adding a line in my copy&quot;</span></code></pre>
+<pre class="output"><code>[master 07ebc69] Adding a line in my copy
+ 1 file changed, 1 insertion(+)</code></pre>
 <p>but Git won't let us push it to GitHub:</p>
-<pre><code>$ git push origin master</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> To https://github.com/vlad/planets.git ! [rejected] master -&gt; master (non-fast-forward) error: failed to push some refs to 'https://github.com/vlad/planets.git' hint: Updates were rejected because the tip of your current branch is behind hint: its remote counterpart. Merge the remote changes (e.g. 'git pull') hint: before pushing again. hint: See the 'Note about fast-forwards' in 'git push --help' for details. <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> push origin master</code></pre>
+<pre class="output"><code>To https://github.com/vlad/planets.git
+ ! [rejected]        master -&gt; master (non-fast-forward)
+error: failed to push some refs to &#39;https://github.com/vlad/planets.git&#39;
+hint: Updates were rejected because the tip of your current branch is behind
+hint: its remote counterpart. Merge the remote changes (e.g. &#39;git pull&#39;)
+hint: before pushing again.
+hint: See the &#39;Note about fast-forwards&#39; in &#39;git push --help&#39; for details.</code></pre>
 <p><img src="img/conflict.svg" alt="The conflicting changes" /></p>
 <p>Git detects that the changes made in one copy overlap with those made in the other and stops us from trampling on our previous work. What we have to do is pull the changes from GitHub, <a href="../../gloss.html#merge">merge</a> them into the copy we're currently working in, and then push that. Let's start by pulling:</p>
-<pre><code>$ git pull origin master</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> remote: Counting objects: 5, done. remote: Compressing objects: 100% (2/2), done. remote: Total 3 (delta 1), reused 3 (delta 1) Unpacking objects: 100% (3/3), done. From https://github.com/vlad/planets * branch master -&gt; FETCH_HEAD Auto-merging mars.txt CONFLICT (content): Merge conflict in mars.txt Automatic merge failed; fix conflicts and then commit the result. <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> pull origin master</code></pre>
+<pre class="output"><code>remote: Counting objects: 5, done.
+remote: Compressing objects: 100% (2/2), done.
+remote: Total 3 (delta 1), reused 3 (delta 1)
+Unpacking objects: 100% (3/3), done.
+From https://github.com/vlad/planets
+ * branch            master     -&gt; FETCH_HEAD
+Auto-merging mars.txt
+CONFLICT (content): Merge conflict in mars.txt
+Automatic merge failed; fix conflicts and then commit the result.</code></pre>
 <p><code>git pull</code> tells us there's a conflict, and marks that conflict in the affected file:</p>
-<pre><code>$ cat mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman But the Mummy will appreciate the lack of humidity &lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD We added a different line in the other copy ======= This line added to Sarah's copy &gt;&gt;&gt;&gt;&gt;&gt;&gt; dabb4c8c450e8475aee9b14b4383acc99f42af1d <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+But the Mummy will appreciate the lack of humidity
+&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD
+We added a different line in the other copy
+=======
+This line added to Sarah&#39;s copy
+&gt;&gt;&gt;&gt;&gt;&gt;&gt; dabb4c8c450e8475aee9b14b4383acc99f42af1d</code></pre>
 <p>Our change---the one in <code>HEAD</code>---is preceded by <code>&lt;&lt;&lt;&lt;&lt;&lt;&lt;</code>. Git has then inserted <code>=======</code> as a separator between the conflicting changes and marked the end of the content downloaded from GitHub with <code>&gt;&gt;&gt;&gt;&gt;&gt;&gt;</code>. (The string of letters and digits after that marker identifies the revision we've just downloaded.)</p>
 <p>It is now up to us to edit this file to remove these markers and reconcile the changes. We can do anything we want: keep the change made in the local repository, keep the change made in the remote repository, write something new to replace both, or get rid of the change entirely. Let's replace both so that the file looks like this:</p>
-<pre><code>$ cat mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman But the Mummy will appreciate the lack of humidity We removed the conflict on this line <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+But the Mummy will appreciate the lack of humidity
+We removed the conflict on this line</code></pre>
 <p>To finish merging, we add <code>mars.txt</code> to the changes being made by the merge and then commit:</p>
-<pre><code>$ git add mars.txt
-$ git status</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> # On branch master # All conflicts fixed but you are still merging. # (use &quot;git commit&quot; to conclude merge) # # Changes to be committed: # # modified: mars.txt # <sub><sub><sub> {:class=&quot;out&quot;} </sub></sub></sub> $ git commit -m &quot;Merging changes from GitHub&quot; <sub><sub><sub> {:class=&quot;in&quot;} </sub></sub></sub> [master 2abf2b1] Merging changes from GitHub <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> add mars.txt
+$ <span class="kw">git</span> status</code></pre>
+<pre class="output"><code># On branch master
+# All conflicts fixed but you are still merging.
+#   (use &quot;git commit&quot; to conclude merge)
+#
+# Changes to be committed:
+#
+#   modified:   mars.txt
+#</code></pre>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> commit -m <span class="st">&quot;Merging changes from GitHub&quot;</span></code></pre>
+<pre class="output"><code>[master 2abf2b1] Merging changes from GitHub</code></pre>
 <p>Now we can push our changes to GitHub:</p>
-<pre><code>$ git push origin master</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Counting objects: 10, done. Delta compression using up to 4 threads. Compressing objects: 100% (6/6), done. Writing objects: 100% (6/6), 697 bytes, done. Total 6 (delta 2), reused 0 (delta 0) To https://github.com/vlad/planets.git dabb4c8..2abf2b1 master -&gt; master <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> push origin master</code></pre>
+<pre class="output"><code>Counting objects: 10, done.
+Delta compression using up to 4 threads.
+Compressing objects: 100% (6/6), done.
+Writing objects: 100% (6/6), 697 bytes, done.
+Total 6 (delta 2), reused 0 (delta 0)
+To https://github.com/vlad/planets.git
+   dabb4c8..2abf2b1  master -&gt; master</code></pre>
 <p>Git keeps track of what we've merged with what, so we don't have to fix things by hand again when the collaborator who made the first change pulls again:</p>
-<pre><code>$ git pull origin master</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> remote: Counting objects: 10, done. remote: Compressing objects: 100% (4/4), done. remote: Total 6 (delta 2), reused 6 (delta 2) Unpacking objects: 100% (6/6), done. From https://github.com/vlad/planets * branch master -&gt; FETCH_HEAD Updating dabb4c8..2abf2b1 Fast-forward mars.txt | 2 +- 1 file changed, 1 insertion(+), 1 deletion(-) <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">git</span> pull origin master</code></pre>
+<pre class="output"><code>remote: Counting objects: 10, done.
+remote: Compressing objects: 100% (4/4), done.
+remote: Total 6 (delta 2), reused 6 (delta 2)
+Unpacking objects: 100% (6/6), done.
+From https://github.com/vlad/planets
+ * branch            master     -&gt; FETCH_HEAD
+Updating dabb4c8..2abf2b1
+Fast-forward
+ mars.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)</code></pre>
 <p>we get the merged file:</p>
-<pre><code>$ cat mars.txt</code></pre>
-<p>{:class=&quot;in&quot;} <sub>~</sub> Cold and dry, but everything is my favorite color The two moons may be a problem for Wolfman But the Mummy will appreciate the lack of humidity We removed the conflict on this line <sub>~</sub> {:class=&quot;out&quot;}</p>
+<pre class="sourceCode bash"><code class="sourceCode bash">$ <span class="kw">cat</span> mars.txt</code></pre>
+<pre class="output"><code>Cold and dry, but everything is my favorite color
+The two moons may be a problem for Wolfman
+But the Mummy will appreciate the lack of humidity
+We removed the conflict on this line</code></pre>
 <p>We don't need to merge again because Git knows someone has already done that.</p>
 <p>Version control's ability to merge conflicting changes is another reason users tend to divide their programs and papers into multiple files instead of storing everything in one large file. There's another benefit too: whenever there are repeated conflicts in a particular file, the version control system is essentially trying to tell its users that they ought to clarify who's responsible for what, or find a way to divide the work up differently.</p>
-<div class="keypoints" markdown="1">
-<h4>Key Points</h4>
+<div id="key-points" class="objectives panel panel-warning">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-certificate"></span>Key Points</h3>
+</div>
+<div class="panel-body">
 <ul>
 <li>Conflicts occur when two or more people change the same file(s) at the same time.</li>
 <li>The version control system does not allow people to blindly overwrite each other's changes. Instead, it highlights conflicts so that they can be resolved.</li>
 </ul>
 </div>
-<div class="challenge" markdown="1">
-Repeat the above exercise with the roles swapped, adding an additional line to the file mars.txt so the other partner deals with the merge conflict.
 </div>
-<div class="challenge" markdown="1">
-What does Git do when there is a conflict in an image or some other non-textual file that is stored in version control?
+<div id="challenge" class="challenge panel panel-success">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-pencil"></span>Challenge</h3>
+</div>
+<div class="panel-body">
+<p>Repeat the above exercise with the roles swapped, adding an additional line to the file mars.txt so the other partner deals with the merge conflict.</p>
+</div>
+</div>
+<div id="challenge-1" class="challenge panel panel-success">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-pencil"></span>Challenge</h3>
+</div>
+<div class="panel-body">
+<p>What does Git do when there is a conflict in an image or some other non-textual file that is stored in version control?</p>
+</div>
 </div>
         </div>
       </div>

--- a/syllabus/git-03-conflict.md
+++ b/syllabus/git-03-conflict.md
@@ -4,13 +4,10 @@ root: ..
 title: Conflicts
 ---
 
-<div class="objectives" markdown="1">
-
-#### Objectives
-*   Explain what conflicts are and when they can occur.
-*   Resolve conflicts resulting from a merge.
-
-</div>
+> ### Objectives {.objectives}
+>
+> *   Explain what conflicts are and when they can occur.
+> *   Resolve conflicts resulting from a merge.
 
 As soon as people can work in parallel,
 someone's going to step on someone else's toes.
@@ -25,49 +22,47 @@ we must first create one.
 The file `mars.txt` currently looks like this
 in both partners' copies of our `planets` repository:
 
-~~~
+~~~ {.bash}
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 The two moons may be a problem for Wolfman
 But the Mummy will appreciate the lack of humidity
 ~~~
-{:class="out"}
 
 Let's add a line to **one partner's copy** only:
 
-~~~
+~~~ {.bash}
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 The two moons may be a problem for Wolfman
 But the Mummy will appreciate the lack of humidity
 This line added to Sarah's copy
 ~~~
-{:class="out"}
 
 and then push the change to GitHub:
 
-~~~
+~~~ {.bash}
 $ git add mars.txt
 $ git commit -m "Adding a line in our home copy"
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 [master 5ae9631] Adding a line in our home copy
  1 file changed, 1 insertion(+)
 ~~~
-{:class="out"}
-~~~
+
+~~~ {.bash}
 $ git push origin master
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Counting objects: 5, done.
 Delta compression using up to 4 threads.
 Compressing objects: 100% (3/3), done.
@@ -76,46 +71,43 @@ Total 3 (delta 1), reused 0 (delta 0)
 To https://github.com/vlad/planets
    29aba7c..dabb4c8  master -> master
 ~~~
-{:class="out"}
 
 Now let's have the other partner
 make a different change to their copy
 *without* updating from GitHub:
 
-~~~
+~~~ {.bash}
 $ cd /tmp/planets
 $ nano mars.txt
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 The two moons may be a problem for Wolfman
 But the Mummy will appreciate the lack of humidity
 We added a different line in the other copy
 ~~~
-{:class="out"}
 
 We can commit the change locally:
 
-~~~
+~~~ {.bash}
 $ git add mars.txt
 $ git commit -m "Adding a line in my copy"
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 [master 07ebc69] Adding a line in my copy
  1 file changed, 1 insertion(+)
 ~~~
-{:class="out"}
 
 but Git won't let us push it to GitHub:
 
-~~~
+~~~ {.bash}
 $ git push origin master
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 To https://github.com/vlad/planets.git
  ! [rejected]        master -> master (non-fast-forward)
 error: failed to push some refs to 'https://github.com/vlad/planets.git'
@@ -124,7 +116,6 @@ hint: its remote counterpart. Merge the remote changes (e.g. 'git pull')
 hint: before pushing again.
 hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 ~~~
-{:class="out"}
 
 <img src="img/conflict.svg" alt="The conflicting changes" />
 
@@ -135,11 +126,11 @@ What we have to do is pull the changes from GitHub,
 and then push that.
 Let's start by pulling:
 
-~~~
+~~~ {.bash}
 $ git pull origin master
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 remote: Counting objects: 5, done.
 remote: Compressing objects: 100% (2/2), done.
 remote: Total 3 (delta 1), reused 3 (delta 1)
@@ -150,16 +141,15 @@ Auto-merging mars.txt
 CONFLICT (content): Merge conflict in mars.txt
 Automatic merge failed; fix conflicts and then commit the result.
 ~~~
-{:class="out"}
 
 `git pull` tells us there's a conflict,
 and marks that conflict in the affected file:
 
-~~~
+~~~ {.bash}
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 The two moons may be a problem for Wolfman
 But the Mummy will appreciate the lack of humidity
@@ -169,7 +159,6 @@ We added a different line in the other copy
 This line added to Sarah's copy
 >>>>>>> dabb4c8c450e8475aee9b14b4383acc99f42af1d
 ~~~
-{:class="out"}
 
 Our change---the one in `HEAD`---is preceded by `<<<<<<<`.
 Git has then inserted `=======` as a separator between the conflicting changes
@@ -184,28 +173,27 @@ the change made in the remote repository, write something new to replace both,
 or get rid of the change entirely.
 Let's replace both so that the file looks like this:
 
-~~~
+~~~ {.bash}
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 The two moons may be a problem for Wolfman
 But the Mummy will appreciate the lack of humidity
 We removed the conflict on this line
 ~~~
-{:class="out"}
 
 To finish merging,
 we add `mars.txt` to the changes being made by the merge
 and then commit:
 
-~~~
+~~~ {.bash}
 $ git add mars.txt
 $ git status
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 # On branch master
 # All conflicts fixed but you are still merging.
 #   (use "git commit" to conclude merge)
@@ -215,23 +203,22 @@ $ git status
 #	modified:   mars.txt
 #
 ~~~
-{:class="out"}
-~~~
+
+~~~ {.bash}
 $ git commit -m "Merging changes from GitHub"
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 [master 2abf2b1] Merging changes from GitHub
 ~~~
-{:class="out"}
 
 Now we can push our changes to GitHub:
 
-~~~
+~~~ {.bash}
 $ git push origin master
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Counting objects: 10, done.
 Delta compression using up to 4 threads.
 Compressing objects: 100% (6/6), done.
@@ -240,17 +227,16 @@ Total 6 (delta 2), reused 0 (delta 0)
 To https://github.com/vlad/planets.git
    dabb4c8..2abf2b1  master -> master
 ~~~
-{:class="out"}
 
 Git keeps track of what we've merged with what,
 so we don't have to fix things by hand again
 when the collaborator who made the first change pulls again:
 
-~~~
+~~~ {.bash}
 $ git pull origin master
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 remote: Counting objects: 10, done.
 remote: Compressing objects: 100% (4/4), done.
 remote: Total 6 (delta 2), reused 6 (delta 2)
@@ -262,21 +248,19 @@ Fast-forward
  mars.txt | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 ~~~
-{:class="out"}
 
 we get the merged file:
 
-~~~
+~~~ {.bash}
 $ cat mars.txt
 ~~~
-{:class="in"}
-~~~
+
+~~~ {.output}
 Cold and dry, but everything is my favorite color
 The two moons may be a problem for Wolfman
 But the Mummy will appreciate the lack of humidity
 We removed the conflict on this line
 ~~~
-{:class="out"}
 
 We don't need to merge again because Git knows someone has already done that.
 
@@ -289,22 +273,20 @@ the version control system is essentially trying to tell its users
 that they ought to clarify who's responsible for what,
 or find a way to divide the work up differently.
 
-<div class="keypoints" markdown="1">
+> ### Key Points {.objectives}
+>
+> *   Conflicts occur when two or more people change the same file(s) at the same time.
+> *   The version control system does not allow people to blindly overwrite each other's changes.
+>     Instead, it highlights conflicts so that they can be resolved.
 
-#### Key Points
-*   Conflicts occur when two or more people change the same file(s) at the same time.
-*   The version control system does not allow people to blindly overwrite each other's changes.
-    Instead, it highlights conflicts so that they can be resolved.
 
-</div>
+> ### Challenge {.challenge}
+>
+> Repeat the above exercise with the roles swapped, adding an additional line to
+> the file mars.txt so the other partner deals with the merge conflict.
 
-<div class="challenge" markdown="1">
-Repeat the above exercise with the roles swapped, adding an additional line to
-the file mars.txt so the other partner deals with the merge conflict.
-</div>
-
-<div class="challenge" markdown="1">
-What does Git do
-when there is a conflict in an image or some other non-textual file
-that is stored in version control?
-</div>
+> ### Challenge {.challenge}
+>
+> What does Git do
+> when there is a conflict in an image or some other non-textual file
+> that is stored in version control?

--- a/syllabus/git-04-open.html
+++ b/syllabus/git-04-open.html
@@ -27,14 +27,18 @@
         <div class="col-md-10 col-md-offset-1">
           <h1 class="title">Open Science</h1>
           
-<div class="objectives" markdown="1">
-<h4>Objectives</h4>
+<div id="objectives" class="objectives panel panel-warning">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-certificate"></span>Objectives</h3>
+</div>
+<div class="panel-body">
 <ul>
 <li>Explain how the GNU General Public License (GPL) differs from most other open licenses.</li>
 <li>Explain the four kinds of restrictions that can be combined in a Creative Commons license.</li>
 <li>Correctly add licensing and citation information to a project repository.</li>
 <li>Outline options for hosting code and data and the pros and cons of each.</li>
 </ul>
+</div>
 </div>
 <blockquote>
 The opposite of &quot;open&quot; isn't &quot;closed&quot;. The opposite of &quot;open&quot; is &quot;broken&quot;. <br/> — John Wilbanks
@@ -83,28 +87,181 @@ https://github.com/jgm/pandoc/issues/1340 -->
 Licenses that can be used for derivative work or adaptation
 </caption>
 <tr>
-<pre><code>&lt;td&gt;Original work&lt;/td&gt; &lt;td&gt;by&lt;/td&gt; &lt;td&gt;by-nc&lt;/td&gt; &lt;td&gt;by-nc-nd&lt;/td&gt; &lt;td&gt;by-nc-sa&lt;/td&gt; &lt;td&gt;by-nd&lt;/td&gt; &lt;td&gt;by-sa&lt;/td&gt; &lt;td&gt;pd&lt;/td&gt;</code></pre>
+<td>
+Original work
+</td>
+<td>
+by
+</td>
+<td>
+by-nc
+</td>
+<td>
+by-nc-nd
+</td>
+<td>
+by-nc-sa
+</td>
+<td>
+by-nd
+</td>
+<td>
+by-sa
+</td>
+<td>
+pd
+</td>
 </tr>
 <tr>
-<pre><code>&lt;td&gt;by&lt;/td&gt;       &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt; &lt;/td&gt;</code></pre>
+<td>
+by
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+</td>
 </tr>
 <tr>
-<pre><code>&lt;td&gt;by-nc&lt;/td&gt;    &lt;td&gt; &lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt;</code></pre>
+<td>
+by-nc
+</td>
+<td>
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
 </tr>
 <tr>
-<pre><code>&lt;td&gt;by-nc-nd&lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt;</code></pre>
+<td>
+by-nc-nd
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
 </tr>
 <tr>
-<pre><code>&lt;td&gt;by-nc-sa&lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt;</code></pre>
+<td>
+by-nc-sa
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+X
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
 </tr>
 <tr>
-<pre><code>&lt;td&gt;by-nd&lt;/td&gt;    &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt;</code></pre>
+<td>
+by-nd
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
 </tr>
 <tr>
-<pre><code>&lt;td&gt;by-sa&lt;/td&gt;    &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt; &lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt; &lt;/td&gt;</code></pre>
+<td>
+by-sa
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+X
+</td>
+<td>
+</td>
 </tr>
 <tr>
-<pre><code>&lt;td&gt;pd&lt;/td&gt;       &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt; &lt;td&gt;X&lt;/td&gt;</code></pre>
+<td>
+pd
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
+<td>
+X
+</td>
 </tr>
 </table>
 <p><a href="http://software-carpentry.org/license.html">Software Carpentry</a> uses CC-BY for its lessons and the MIT License for its code in order to encourage the widest possible re-use. Again, the most important thing is for the <code>LICENSE</code> file in the root directory of your project to state clearly what your license is. You may also want to include a file called <code>CITATION</code> or <code>CITATION.txt</code> that describes how to reference your project; the one for Software Carpentry states:</p>
@@ -127,9 +284,9 @@ Greg Wilson: &quot;Software Carpentry: Lessons Learned&quot;. arXiv:1307.5448, J
 <p>Another option is to purchase a domain and pay an Internet service provider (ISP) to host it. This gives the individual or group more control, and sidesteps problems that can arise when moving from one institution to another, but requires more time and effort to set up than either the option above or the option below.</p>
 <p>The third option is to use a public hosting service like <a href="http://github.com">GitHub</a>, <a href="http://bitbucket.org">BitBucket</a>, <a href="http://code.google.com">Google Code</a>, or <a href="http://sourceforge.net">SourceForge</a>. All of these allow people to create repositories through a web interface, and also provide mailing lists, ways to keep track of who's doing what, and so on. They all benefit from economies of scale and network effects: it's easier to run one large service well than to run many smaller services to the same standard, and it's also easier for people to collaborate if they're using the same service, not least because it gives them fewer passwords to remember.</p>
 <p>However, all of these services place some constraints on people's work. In particular, most give users a choice: if they're willing to share their work with others, it will be hosted for free, but if they want privacy, they may have to pay. Sharing might seem like the only valid choice for science, but many institutions may not allow researchers to do this, either because they want to protect future patent applications or simply because what's new is often also frightening.</p>
-<p><strong>Link to 9 simple ways to share your data paper: http://library.queensu.ca/ojs/index.php/IEE/article/view/4608 https://peerj.com/preprints/7/</strong></p>
-<div class="keypoints" markdown="1">
-<h4>Key Points</h4>
+<p><strong>Link to 9 simple ways to share your data paper: <a href="http://library.queensu.ca/ojs/index.php/IEE/article/view/4608" class="uri">http://library.queensu.ca/ojs/index.php/IEE/article/view/4608</a> <a href="https://peerj.com/preprints/7/" class="uri">https://peerj.com/preprints/7/</a> </strong></p>
+<blockquote>
+<h3>Key Points</h3>
 <ul>
 <li>Open scientific work is more useful and more highly cited than closed.</li>
 <li>People who incorporate GPL'd software into theirs must make theirs open; most other open licenses do not require this.</li>
@@ -138,12 +295,22 @@ Greg Wilson: &quot;Software Carpentry: Lessons Learned&quot;. arXiv:1307.5448, J
 <li>Projects can be hosted on university servers, on personal domains, or on public forges.</li>
 <li>Rules regarding intellectual property and storage of sensitive information apply no matter where code and data are hosted.</li>
 </ul>
+</blockquote>
+<div id="challenge" class="challenge panel panel-success">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-pencil"></span>Challenge</h3>
 </div>
-<div class="challenge" markdown="1">
-Find out whether you are allowed to apply an open license to your software. Can you do this unilaterally, or do you need permission from someone in your institution? If so, who?
+<div class="panel-body">
+<p>Find out whether you are allowed to apply an open license to your software. Can you do this unilaterally, or do you need permission from someone in your institution? If so, who?</p>
 </div>
-<div class="challenge" markdown="1">
-Find out whether you are allowed to host your work openly on a public forge. Can you do this unilaterally, or do you need permission from someone in your institution? If so, who?
+</div>
+<div id="challenge-1" class="challenge panel panel-success">
+<div class="panel-heading">
+<h3><span class="glyphicon glyphicon-pencil"></span>Challenge</h3>
+</div>
+<div class="panel-body">
+<p>Find out whether you are allowed to host your work openly on a public forge. Can you do this unilaterally, or do you need permission from someone in your institution? If so, who?</p>
+</div>
 </div>
         </div>
       </div>

--- a/syllabus/git-04-open.md
+++ b/syllabus/git-04-open.md
@@ -4,15 +4,13 @@ root: ..
 title: Open Science
 ---
 
-<div class="objectives" markdown="1">
+> ### Objectives {.objectives}
+>
+> *   Explain how the GNU General Public License (GPL) differs from most other open licenses.
+> *   Explain the four kinds of restrictions that can be combined in a Creative Commons license.
+> *   Correctly add licensing and citation information to a project repository.
+> *   Outline options for hosting code and data and the pros and cons of each.
 
-#### Objectives
-*   Explain how the GNU General Public License (GPL) differs from most other open licenses.
-*   Explain the four kinds of restrictions that can be combined in a Creative Commons license.
-*   Correctly add licensing and citation information to a project repository.
-*   Outline options for hosting code and data and the pros and cons of each.
-
-</div>
 
 <blockquote>
 The opposite of "open" isn't "closed".
@@ -148,31 +146,16 @@ The table below shows how the six Creative Commons licenses and PD relate to one
 <!--- Replace the caption with colspan when it was supported by pandoc:
 https://github.com/jgm/pandoc/issues/1340 -->
 <table border="1">
-  <caption>Licenses that can be used for derivative work or adaptation</caption>
-  <tr>
-    <td>Original work</td> <td>by</td> <td>by-nc</td> <td>by-nc-nd</td> <td>by-nc-sa</td> <td>by-nd</td> <td>by-sa</td> <td>pd</td>
-  </tr>
-  <tr>
-    <td>by</td>       <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td> </td>
-  </tr>
-  <tr>
-    <td>by-nc</td>    <td> </td> <td>X</td> <td>X</td> <td>X</td> <td> </td> <td> </td> <td> </td>
-  </tr>
-  <tr>
-    <td>by-nc-nd</td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td>
-  </tr>
-  <tr>
-    <td>by-nc-sa</td> <td> </td> <td> </td> <td> </td> <td>X</td> <td> </td> <td> </td> <td> </td>
-  </tr>
-  <tr>
-    <td>by-nd</td>    <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td>
-  </tr>
-  <tr>
-    <td>by-sa</td>    <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td>X</td> <td> </td>
-  </tr>
-  <tr>
-    <td>pd</td>       <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td>
-  </tr>
+<caption>Licenses that can be used for derivative work or adaptation</caption>
+<tr>
+<td>Original work</td> <td>by</td> <td>by-nc</td> <td>by-nc-nd</td> <td>by-nc-sa</td> <td>by-nd</td> <td>by-sa</td> <td>pd</td></tr>
+<tr><td>by</td><td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td> </td></tr>
+<tr><td>by-nc</td><td> </td> <td>X</td> <td>X</td> <td>X</td> <td> </td> <td> </td> <td> </td></tr>
+<tr><td>by-nc-nd</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td></tr>
+<tr><td>by-nc-sa</td><td> </td> <td> </td> <td> </td> <td>X</td> <td> </td> <td> </td> <td> </td></tr>
+<tr><td>by-nd</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td></tr>
+<tr><td>by-sa</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td>X</td> <td> </td></tr>
+<tr><td>pd</td><td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td> <td>X</td></tr>
 </table>
 
 [Software Carpentry](http://software-carpentry.org/license.html)
@@ -254,39 +237,37 @@ either because they want to protect future patent applications
 or simply because what's new is often also frightening.
 
 __Link to 9 simple ways to share your data paper:
-http://library.queensu.ca/ojs/index.php/IEE/article/view/4608
-https://peerj.com/preprints/7/__
+<http://library.queensu.ca/ojs/index.php/IEE/article/view/4608>
+<https://peerj.com/preprints/7/> __
 
-<div class="keypoints" markdown="1">
+> ### Key Points {.objective}
+>
+> *   Open scientific work is more useful and more highly cited than closed.
+> *   People who incorporate GPL'd software into theirs must make theirs open;
+>     most other open licenses do not require this.
+> *   The Creative Commons family of licenses allow people to mix and match
+>     requirements and restrictions on attribution,
+>     creation of derivative works,
+>     further sharing,
+>     and commercialization.
+> *   People who are not lawyers should not try to write licenses from scratch.
+> *   Projects can be hosted on university servers,
+>     on personal domains,
+>     or on public forges.
+> *   Rules regarding intellectual property and storage of sensitive information apply
+>     no matter where code and data are hosted.
 
-#### Key Points
-*   Open scientific work is more useful and more highly cited than closed.
-*   People who incorporate GPL'd software into theirs must make theirs open;
-    most other open licenses do not require this.
-*   The Creative Commons family of licenses allow people to mix and match
-    requirements and restrictions on attribution,
-    creation of derivative works,
-    further sharing,
-    and commercialization.
-*   People who are not lawyers should not try to write licenses from scratch.
-*   Projects can be hosted on university servers,
-    on personal domains,
-    or on public forges.
-*   Rules regarding intellectual property and storage of sensitive information apply
-    no matter where code and data are hosted.
 
-</div>
+> ### Challenge {.challenge}
+>
+> Find out whether you are allowed to apply an open license to your software.
+> Can you do this unilaterally,
+> or do you need permission from someone in your institution?
+> If so, who?
 
-<div class="challenge" markdown="1">
-Find out whether you are allowed to apply an open license to your software.
-Can you do this unilaterally,
-or do you need permission from someone in your institution?
-If so, who?
-</div>
-
-<div class="challenge" markdown="1">
-Find out whether you are allowed to host your work openly on a public forge.
-Can you do this unilaterally,
-or do you need permission from someone in your institution?
-If so, who?
-</div>
+> ### Challenge {.challenge}
+>
+> Find out whether you are allowed to host your work openly on a public forge.
+> Can you do this unilaterally,
+> or do you need permission from someone in your institution?
+> If so, who?


### PR DESCRIPTION
- Formatting in the git lessons was all messed up as it used some different system for defining the input and output chunks.
