### PR TITLE
chunk_options.R: remove hook_in/out so they don't show up in R_intro_00

### DIFF
--- a/syllabus/R_intro_00.html
+++ b/syllabus/R_intro_00.html
@@ -68,7 +68,7 @@ y</code></pre>
 </code></pre>
 <p>To view the objects that are in your current environment, use <code>ls()</code>.</p>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">ls</span>()</code></pre>
-<pre class="output"><code>[1] &quot;hook_in&quot;  &quot;hook_out&quot; &quot;x&quot;        &quot;y&quot;       
+<pre class="output"><code>[1] &quot;x&quot; &quot;y&quot;
 </code></pre>
 <h3 id="vectors-and-data-types">Vectors and data types</h3>
 <p><em>Adapted from Christie Bahlai's <a href="https://github.com/cbahlai/2015-01-05-wise-umich/">materials</a> for the 2015-01-05 UMich workshop</em></p>

--- a/syllabus/R_intro_00.md
+++ b/syllabus/R_intro_00.md
@@ -113,7 +113,7 @@ ls()
 
 
 ~~~{.output}
-[1] "hook_in"  "hook_out" "x"        "y"       
+[1] "x" "y"
 
 ~~~
 

--- a/syllabus/chunk_options.R
+++ b/syllabus/chunk_options.R
@@ -24,3 +24,6 @@ hook_out <- function(x, options) {
 
 knit_hooks$set(source = hook_in, output = hook_out, warning = hook_out,
                error = hook_out, message = hook_out)
+
+# remove those functions so they don't show up in ls()
+rm(hook_in, hook_out)


### PR DESCRIPTION
Created `x` and `y` and then used `ls()` and the result mysteriously included `hook_in` and `hook_out`.
